### PR TITLE
Add web vault support for alternate base dir (subdir/subpath) hosting

### DIFF
--- a/patches/v2.12.0.patch
+++ b/patches/v2.12.0.patch
@@ -1,0 +1,105 @@
+diff --git a/src/app/services/services.module.ts b/src/app/services/services.module.ts
+index a92bf70c..0ebcfc8f 100644
+--- a/src/app/services/services.module.ts
++++ b/src/app/services/services.module.ts
+@@ -123,22 +123,31 @@ const environmentService = new EnvironmentService(apiService, storageService, no
+ const auditService = new AuditService(cryptoFunctionService, apiService);
+ const eventLoggingService = new EventLoggingService(storageService, apiService, userService, cipherService);
+ 
+-const analytics = new Analytics(window, () => platformUtilsService.isDev() || platformUtilsService.isSelfHost(),
++const analytics = new Analytics(window, () => platformUtilsService.isDev() || platformUtilsService.isSelfHost() || true,
+     platformUtilsService, storageService, appIdService);
+ containerService.attachToWindow(window);
+ 
+ export function initFactory(): Function {
++    function getBaseUrl() {
++        // If the base URL is `https://bitwarden.example.com/base/path/`,
++        // `window.location.href` should have one of the following forms:
++        //
++        // - `https://bitwarden.example.com/base/path/`
++        // - `https://bitwarden.example.com/base/path/#/some/endpoint[?queryParam=...]`
++        //
++        // We want to get to just `https://bitwarden.example.com/base/path`.
++        let baseUrl = window.location.href;
++        baseUrl = baseUrl.replace(/#.*/, '');  // Strip off `#` and everything after.
++        baseUrl = baseUrl.replace(/\/+$/, ''); // Trim any trailing `/` chars.
++        return baseUrl;
++    }
+     return async () => {
+         await (storageService as HtmlStorageService).init();
+-        const isDev = platformUtilsService.isDev();
+-        if (!isDev && platformUtilsService.isSelfHost()) {
+-            environmentService.baseUrl = window.location.origin;
+-        } else {
+-            environmentService.notificationsUrl = isDev ? 'http://localhost:61840' :
+-                'https://notifications.bitwarden.com'; // window.location.origin + '/notifications';
+-        }
++        const isDev = false;
++        environmentService.baseUrl = getBaseUrl();
++        environmentService.notificationsUrl = environmentService.baseUrl + '/notifications';
+         apiService.setUrls({
+-            base: isDev ? null : window.location.origin,
++            base: isDev ? null : environmentService.baseUrl,
+             api: isDev ? 'http://localhost:4000' : null,
+             identity: isDev ? 'http://localhost:33656' : null,
+             events: isDev ? 'http://localhost:46273' : null,
+diff --git a/src/app/settings/two-factor-u2f.component.ts b/src/app/settings/two-factor-u2f.component.ts
+index 5560c476..a9b954a8 100644
+--- a/src/app/settings/two-factor-u2f.component.ts
++++ b/src/app/settings/two-factor-u2f.component.ts
+@@ -128,6 +128,7 @@ export class TwoFactorU2fComponent extends TwoFactorBaseComponent implements OnI
+         (window as any).u2f.register(u2fChallenge.appId, [{
+             version: u2fChallenge.version,
+             challenge: u2fChallenge.challenge,
++            attestation: 'direct',
+         }], [], (data: any) => {
+             this.ngZone.run(() => {
+                 this.u2fListening = false;
+diff --git a/src/scss/styles.scss b/src/scss/styles.scss
+index 2e1dbec9..9f01a7b9 100644
+--- a/src/scss/styles.scss
++++ b/src/scss/styles.scss
+@@ -1,5 +1,31 @@
+ @import "../css/webfonts.css";
+ 
++/**** START Bitwarden_RS CHANGES ****/
++/* This combines all selectors extending it into one */
++%bwrs-hide { display: none !important; }
++
++/* This allows searching for the combined style in the browsers dev-tools (look into the head tag) */
++#bwrs-hide, head { @extend %bwrs-hide; }
++
++/* Hide any link pointing to billing */
++a[href$="/settings/billing"] { @extend %bwrs-hide; }
++
++/* Hide any link pointing to subscriptions */
++a[href$="/settings/subscription"] { @extend %bwrs-hide; }
++
++/* Hide Two-Factor menu in Organization settings */
++app-org-settings a[href$="/settings/two-factor"] { @extend %bwrs-hide; }
++
++/* Hide organization plans */
++app-organization-plans > form > div.form-check { @extend %bwrs-hide; }
++app-organization-plans > form > h2.mt-5 { @extend %bwrs-hide; }
++
++/* Hide Tax Info in Organization settings */
++app-org-account > div.secondary-header.border-0.mb-0:nth-child(3) { @extend %bwrs-hide; }
++app-org-account > p { @extend %bwrs-hide; }
++app-org-account > a.btn.btn-outline-secondary { @extend %bwrs-hide; }
++/**** END Bitwarden_RS CHANGES ****/
++
+ $primary: #3c8dbc;
+ $primary-accent: #286090;
+ $secondary: #ced4da;
+diff --git a/webpack.config.js b/webpack.config.js
+index aecb1860..44acdc1d 100644
+--- a/webpack.config.js
++++ b/webpack.config.js
+@@ -170,6 +170,7 @@ const config = {
+         },
+         minimizer: [
+             new TerserPlugin({
++                sourceMap: true,
+                 terserOptions: {
+                     safari10: true,
+                 },


### PR DESCRIPTION
Instead of assuming the base URL is always `window.location.origin`,
infer it from `window.location.href`.

Requires dani-garcia/bitwarden_rs#868 for matching backend support.