### PR TITLE
Hide the `Enterprise Single Sign-On` button on the login page

### DIFF
--- a/patches/v2.16.0.patch
+++ b/patches/v2.16.0.patch
@@ -74,10 +74,10 @@ index 5560c476..a9b954a8 100644
              this.ngZone.run(() => {
                  this.u2fListening = false;
 diff --git a/src/scss/styles.scss b/src/scss/styles.scss
-index 676e275f..ba9888fc 100644
+index 676e275f..ab3304af 100644
 --- a/src/scss/styles.scss
 +++ b/src/scss/styles.scss
-@@ -1,5 +1,31 @@
+@@ -1,5 +1,34 @@
  @import "../css/webfonts.css";
  
 +/**** START Bitwarden_RS CHANGES ****/
@@ -92,6 +92,9 @@ index 676e275f..ba9888fc 100644
 +
 +/* Hide any link pointing to subscriptions */
 +a[href$="/settings/subscription"] { @extend %bwrs-hide; }
++
++/* Hide the `Enterprise Single Sign-On` button on the login page */
++a[href$="/sso"] { @extend %bwrs-hide; }
 +
 +/* Hide Two-Factor menu in Organization settings */
 +app-org-settings a[href$="/settings/two-factor"] { @extend %bwrs-hide; }


### PR DESCRIPTION
bitwarden_rs doesn't currently support the new upstream SSO functionality,
but showing the button would probably give the impression that it does.