### PR TITLE
Update to upstream v2.17.1 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ USER node
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/web/commit/$VAULT_VERSION
 #
-# Using https://github.com/bitwarden/web/releases/tag/v2.16.1
-ARG VAULT_VERSION=949f61f1a46a0ce680e9a39e6240f7b66b1b6efe
+# Using https://github.com/bitwarden/web/releases/tag/v2.17.1
+ARG VAULT_VERSION=5e95a8565c3ec70176d77af312707b16975ba485
 
 RUN git clone https://github.com/bitwarden/web.git /vault
 WORKDIR /vault

--- a/patches/v2.17.1.patch
+++ b/patches/v2.17.1.patch
@@ -1,0 +1,134 @@
+diff --git a/src/app/app.component.ts b/src/app/app.component.ts
+index 51853633..c9b3d48a 100644
+--- a/src/app/app.component.ts
++++ b/src/app/app.component.ts
+@@ -140,6 +140,10 @@ export class AppComponent implements OnDestroy, OnInit {
+                         }
+                         break;
+                     case 'showToast':
++                        if (typeof message.text === "string" && (message.text.indexOf("this.subtle") != -1 || message.text.indexOf("importKey") != -1)) {
++                            message.title="This browser requires HTTPS to use the web vault";
++                            message.text="Check the bitwarden_rs wiki for details on how to enable it";
++                        }
+                         this.showToast(message);
+                         break;
+                     case 'analyticsEventTrack':
+diff --git a/src/app/services/services.module.ts b/src/app/services/services.module.ts
+index 092af73a..95eb8f49 100644
+--- a/src/app/services/services.module.ts
++++ b/src/app/services/services.module.ts
+@@ -131,24 +131,32 @@ const environmentService = new EnvironmentService(apiService, storageService, no
+ const auditService = new AuditService(cryptoFunctionService, apiService);
+ const eventLoggingService = new EventLoggingService(storageService, apiService, userService, cipherService);
+ 
+-const analytics = new Analytics(window, () => platformUtilsService.isDev() || platformUtilsService.isSelfHost(),
++const analytics = new Analytics(window, () => platformUtilsService.isDev() || platformUtilsService.isSelfHost() || true,
+     platformUtilsService, storageService, appIdService);
+ containerService.attachToWindow(window);
+ 
+ export function initFactory(): Function {
++    function getBaseUrl() {
++        // If the base URL is `https://bitwarden.example.com/base/path/`,
++        // `window.location.href` should have one of the following forms:
++        //
++        // - `https://bitwarden.example.com/base/path/`
++        // - `https://bitwarden.example.com/base/path/#/some/route[?queryParam=...]`
++        //
++        // We want to get to just `https://bitwarden.example.com/base/path`.
++        let baseUrl = window.location.href;
++        baseUrl = baseUrl.replace(/#.*/, '');  // Strip off `#` and everything after.
++        baseUrl = baseUrl.replace(/\/+$/, ''); // Trim any trailing `/` chars.
++        return baseUrl;
++    }
+     return async () => {
+         await (storageService as HtmlStorageService).init();
+-        const isDev = platformUtilsService.isDev();
+-        if (!isDev && platformUtilsService.isSelfHost()) {
+-            environmentService.baseUrl = window.location.origin;
+-        } else {
+-            environmentService.notificationsUrl = isDev ? 'http://localhost:61840' :
+-                'https://notifications.bitwarden.com'; // window.location.origin + '/notifications';
+-            environmentService.enterpriseUrl = isDev ? 'http://localhost:52313' :
+-                'https://portal.bitwarden.com'; // window.location.origin + '/portal';
+-        }
++        const isDev = false;
++        environmentService.baseUrl = getBaseUrl();
++        environmentService.notificationsUrl = environmentService.baseUrl + '/notifications';
++        environmentService.enterpriseUrl = environmentService.baseUrl + '/portal';
+         apiService.setUrls({
+-            base: isDev ? null : window.location.origin,
++            base: isDev ? null : environmentService.baseUrl,
+             api: isDev ? 'http://localhost:4000' : null,
+             identity: isDev ? 'http://localhost:33656' : null,
+             events: isDev ? 'http://localhost:46273' : null,
+diff --git a/src/app/settings/two-factor-u2f.component.ts b/src/app/settings/two-factor-u2f.component.ts
+index 5560c476..a9b954a8 100644
+--- a/src/app/settings/two-factor-u2f.component.ts
++++ b/src/app/settings/two-factor-u2f.component.ts
+@@ -128,6 +128,7 @@ export class TwoFactorU2fComponent extends TwoFactorBaseComponent implements OnI
+         (window as any).u2f.register(u2fChallenge.appId, [{
+             version: u2fChallenge.version,
+             challenge: u2fChallenge.challenge,
++            attestation: 'direct',
+         }], [], (data: any) => {
+             this.ngZone.run(() => {
+                 this.u2fListening = false;
+diff --git a/src/scss/styles.scss b/src/scss/styles.scss
+index 55b3c92c..91279fef 100644
+--- a/src/scss/styles.scss
++++ b/src/scss/styles.scss
+@@ -1,5 +1,42 @@
+ @import "../css/webfonts.css";
+ 
++/**** START Bitwarden_RS CHANGES ****/
++/* This combines all selectors extending it into one */
++%bwrs-hide { display: none !important; }
++
++/* This allows searching for the combined style in the browsers dev-tools (look into the head tag) */
++#bwrs-hide, head { @extend %bwrs-hide; }
++
++/* Hide any link pointing to billing */
++a[href$="/settings/billing"] { @extend %bwrs-hide; }
++
++/* Hide any link pointing to subscriptions */
++a[href$="/settings/subscription"] { @extend %bwrs-hide; }
++
++/* Hide the `Enterprise Single Sign-On` button on the login page */
++a[href$="/sso"] { @extend %bwrs-hide; }
++
++/* Hide Two-Factor menu in Organization settings */
++app-org-settings a[href$="/settings/two-factor"] { @extend %bwrs-hide; }
++
++/* Hide organization plans */
++app-organization-plans > form > div.form-check { @extend %bwrs-hide; }
++app-organization-plans > form > h2.mt-5 { @extend %bwrs-hide; }
++
++/* Hide the `API Key` section under `My Account` */
++app-account > div:nth-child(9),
++app-account > p,
++app-account > button:nth-child(11),
++app-account > button:nth-child(12) {
++    @extend %bwrs-hide;
++}
++
++/* Hide Tax Info and Form in Organization settings */
++app-org-account > div.secondary-header:nth-child(3) { @extend %bwrs-hide; }
++app-org-account > div.secondary-header:nth-child(3) + p { @extend %bwrs-hide; }
++app-org-account > div.secondary-header:nth-child(3) + p + form { @extend %bwrs-hide; }
++/**** END Bitwarden_RS CHANGES ****/
++
+ $primary: #175DDC;
+ $primary-accent: #1252A3;
+ $secondary: #ced4da;
+diff --git a/webpack.config.js b/webpack.config.js
+index 6b01c93d..809b396a 100644
+--- a/webpack.config.js
++++ b/webpack.config.js
+@@ -176,6 +176,7 @@ const config = {
+         },
+         minimizer: [
+             new TerserPlugin({
++                sourceMap: true,
+                 terserOptions: {
+                     safari10: true,
+                 },


### PR DESCRIPTION
This release includes support for passing the web client's last known revision date for a cipher, which the server can use to reject a client's attempt to update a cipher based on an outdated previous version.