### PR TITLE
Added warning when no HTTPS during register.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
 # Bitwarden_rs web vault builds
 
 [![GitHub Release](https://img.shields.io/github/release/dani-garcia/bw_web_builds.svg)](https://github.com/dani-garcia/bw_web_builds/releases/latest)
+[![Docker Pulls](https://img.shields.io/docker/pulls/bitwardenrs/web-vault.svg)](https://hub.docker.com/r/bitwardenrs/web-vault)
 [![GPL-3.0 Licensed](https://img.shields.io/github/license/dani-garcia/bw_web_builds.svg)](https://github.com/dani-garcia/bw_web_builds/blob/master/LICENSE.txt)
-[![Matrix Chat](https://matrix.to/img/matrix-badge.svg)](https://matrix.to/#/#bitwarden_rs:matrix.org)
+[![Matrix Chat](https://img.shields.io/matrix/bitwarden_rs:matrix.org.svg?logo=matrix)](https://matrix.to/#/#bitwarden_rs:matrix.org)
 
 This is a repository to store the builds of the [Bitwarden web vault](https://github.com/bitwarden/web) with the patches to make it work with [bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs)
+
+To create a patch you need to modify the original sources from [Bitwarden web vault](https://github.com/bitwarden/web) and execute:
+
+```bash
+git diff --submodule=diff
+```
+
+This is needed because there are patches within the jslib submodule which with a default `git diff` are not shown.
+
+For more information see: [Install the web-vault](https://github.com/dani-garcia/bitwarden_rs/wiki/Building-binary#install-the-web-vault)
 
 The builds are available in the [releases page](https://github.com/dani-garcia/bw_web_builds/releases), and can be replicated with the scripts in this repo.
 

--- a/patches/v2.18.1.patch
+++ b/patches/v2.18.1.patch
@@ -1,12 +1,30 @@
+Submodule jslib contains modified content
+diff --git a/jslib/src/angular/components/register.component.ts b/jslib/src/angular/components/register.component.ts
+index 6149f83..005d528 100644
+--- a/jslib/src/angular/components/register.component.ts
++++ b/jslib/src/angular/components/register.component.ts
+@@ -69,6 +69,12 @@ export class RegisterComponent {
+     }
+ 
+     async submit() {
++        if (typeof crypto.subtle === 'undefined') {
++            this.platformUtilsService.showToast('error', "This browser requires HTTPS to use the web vault",
++                "Check the bitwarden_rs wiki for details on how to enable it");
++            return;
++        }
++
+         if (!this.acceptPolicies && this.showTerms) {
+             this.platformUtilsService.showToast('error', this.i18nService.t('errorOccurred'),
+                 this.i18nService.t('acceptPoliciesError'));
 diff --git a/src/app/app.component.ts b/src/app/app.component.ts
-index 51853633..c9b3d48a 100644
+index 51853633..f589e498 100644
 --- a/src/app/app.component.ts
 +++ b/src/app/app.component.ts
 @@ -140,6 +140,10 @@ export class AppComponent implements OnDestroy, OnInit {
                          }
                          break;
                      case 'showToast':
-+                        if (typeof message.text === "string" && (message.text.indexOf("this.subtle") != -1 || message.text.indexOf("importKey") != -1)) {
++                        if (typeof message.text === "string" && typeof crypto.subtle === 'undefined') {
 +                            message.title="This browser requires HTTPS to use the web vault";
 +                            message.text="Check the bitwarden_rs wiki for details on how to enable it";
 +                        }
@@ -134,15 +152,3 @@ index 55b3c92c..c48e2baf 100644
  $primary: #175DDC;
  $primary-accent: #1252A3;
  $secondary: #ced4da;
-diff --git a/webpack.config.js b/webpack.config.js
-index b6da3558..eef05772 100644
---- a/webpack.config.js
-+++ b/webpack.config.js
-@@ -178,6 +178,7 @@ const config = {
-         },
-         minimizer: [
-             new TerserPlugin({
-+                sourceMap: true,
-                 terserOptions: {
-                     safari10: true,
-                 },


### PR DESCRIPTION
We already had a patch to warn users they need HTTPS when they login.
This was not working for the register form.

- Added a warning during the submit of the register form.
- Changed the check to see if `crypto.subtle` is defined or not.
- Removed the `webpack.config.js` patch, since this now is in upstream.
- Updated README.md shields and small comment regarding how to create
  the patch because of changes to the submodule.