### PR TITLE
Add config for show/hide signup button

### DIFF
--- a/patches/v2.21.1.patch
+++ b/patches/v2.21.1.patch
@@ -59,6 +59,51 @@ index eba36375..cb8883ec 100644
          </div>
      </body>
  </html>
+diff --git a/src/app-config.js b/src/app-config.js
+new file mode 100644
+index 00000000..f4fffeed
+--- /dev/null
++++ b/src/app-config.js
+@@ -0,0 +1 @@
++window.VW_SIGNUPS_ALLOWED = true;
+diff --git a/src/app/accounts/login.component.html b/src/app/accounts/login.component.html
+index 97d5c478..44778bdd 100644
+--- a/src/app/accounts/login.component.html
++++ b/src/app/accounts/login.component.html
+@@ -43,7 +43,7 @@
+                             </span>
+                             <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
+                         </button>
+-                        <a routerLink="/register" [queryParams]="{email: email}"
++                        <a *ngIf="VW_SIGNUPS_ALLOWED" routerLink="/register" [queryParams]="{email: email}"
+                             class="btn btn-outline-secondary btn-block ml-2 mt-0">
+                             <i class="fa fa-pencil-square-o" aria-hidden="true"></i> {{'createAccount' | i18n}}
+                         </a>
+diff --git a/src/app/accounts/login.component.ts b/src/app/accounts/login.component.ts
+index d705f097..47d1e7f9 100644
+--- a/src/app/accounts/login.component.ts
++++ b/src/app/accounts/login.component.ts
+@@ -19,6 +19,12 @@ import { LoginComponent as BaseLoginComponent } from 'jslib-angular/components/l
+
+ import { Policy } from 'jslib-common/models/domain/policy';
+
++declare global {
++    interface Window {
++        VW_SIGNUPS_ALLOWED: boolean;
++    }
++}
++
+ @Component({
+     selector: 'app-login',
+     templateUrl: 'login.component.html',
+@@ -26,6 +32,7 @@ import { Policy } from 'jslib-common/models/domain/policy';
+ export class LoginComponent extends BaseLoginComponent {
+
+     showResetPasswordAutoEnrollWarning = false;
++    VW_SIGNUPS_ALLOWED = window.VW_SIGNUPS_ALLOWED;
+
+     constructor(authService: AuthService, router: Router,
+         i18nService: I18nService, private route: ActivatedRoute,
 diff --git a/src/app/app.component.ts b/src/app/app.component.ts
 index 2922cf09..8f2be1ad 100644
 --- a/src/app/app.component.ts
@@ -193,6 +238,18 @@ index 41216ead..70dec887 100644
 
          const queryParamsSub = this.route.queryParams.subscribe(async params => {
              await this.syncService.fullSync(false);
+diff --git a/src/index.html b/src/index.html
+index 3c663967..753c1877 100644
+--- a/src/index.html
++++ b/src/index.html
+@@ -13,6 +13,7 @@
+     <link rel="icon" type="image/png" sizes="16x16" href="images/icons/favicon-16x16.png">
+     <link rel="mask-icon" href="images/icons/safari-pinned-tab.svg" color="#175DDC">
+     <link rel="manifest" href="manifest.json">
++    <script src="app-config.js"></script>
+ </head>
+
+ <body class="layout_frontend">
 diff --git a/src/scss/styles.scss b/src/scss/styles.scss
 index 598fea83..f5ed4253 100644
 --- a/src/scss/styles.scss
@@ -276,3 +333,15 @@ index e3aeea39..6e7ed1e0 100644
      }
 
      copyToClipboard(text: string, options?: any): void | boolean {
+diff --git a/webpack.config.js b/webpack.config.js
+index 58a656d4..ca24525c 100644
+--- a/webpack.config.js
++++ b/webpack.config.js
+@@ -118,6 +118,7 @@ const plugins = [
+             { from: './src/manifest.json' },
+             { from: './src/favicon.ico' },
+             { from: './src/browserconfig.xml' },
++            { from: './src/app-config.js'},
+             { from: './src/app-id.json' },
+             { from: './src/404.html' },
+             { from: './src/404', to: '404' },


### PR DESCRIPTION
Now the signup button is still shown even when ENV `SIGNUPS_ALLOWED` is set to `false`.

I checked the `bitwarden/web` files, and add some config for hiding the signup button.

1. add `VW_SIGNUPS_ALLOWED` variable in login component, and the button will show when `VW_SIGNUPS_ALLOWED` is true.
2. add `app-config.js` import in index.html to load dynamic config.
3. add `app-config.js` file to bitwarden/web:src directory, `VW_SIGNUPS_ALLOWED` is default to `true`.
4. add config to webpack to package app-config.js

Now the signup button show/hide can be config dynamicly by the global variable `VW_SIGNUPS_ALLOWED`.

When vaultwarden/server docker image startup, we can echo below to `/web-vault/app-config.js`, and the page will load the config. So the login component will hide signup button.

```
window.VW_SIGNUPS_ALLOWED=${SIGNUPS_ALLOWED:-true}
```

I build the docker image locally, but bitwarden/web build failed. I don't know why. 
Could you please review this PR, and build the docker image to check if it works?

```
docker build -t vw_web .                   
[+] Building 99.0s (17/23)                                                                                                                                                                            
 => [internal] load build definition from Dockerfile                                                                                                                                             0.0s
 => => transferring dockerfile: 37B                                                                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                                                                0.0s
 => => transferring context: 34B                                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/node:14-buster                                                                                                                                1.1s
 => [build  1/17] FROM docker.io/library/node:14-buster@sha256:58370f99e5f56d62847535fbcec9add28dcf44e20f32b56c5e24f5a133e88c61                                                                  0.0s
 => [internal] load build context                                                                                                                                                                0.0s
 => => transferring context: 760B                                                                                                                                                                0.0s
 => CACHED [build  2/17] RUN npm -g install npm@7                                                                                                                                                0.0s
 => CACHED [build  3/17] RUN mkdir /vault                                                                                                                                                        0.0s
 => CACHED [build  4/17] RUN chown node:node /vault                                                                                                                                              0.0s
 => CACHED [build  5/17] RUN git clone https://github.com/bitwarden/web.git /vault                                                                                                               0.0s
 => CACHED [build  6/17] WORKDIR /vault                                                                                                                                                          0.0s
 => CACHED [build  7/17] RUN git checkout "62cd45030ad5b0a0bdbd08f0579f8ffac91a48a4" &&     git submodule update --recursive --init                                                              0.0s
 => CACHED [build  8/17] COPY --chown=node:node patches /patches                                                                                                                                 0.0s
 => CACHED [build  9/17] COPY --chown=node:node apply_patches.sh /apply_patches.sh                                                                                                               0.0s
 => CACHED [build 10/17] RUN bash /apply_patches.sh                                                                                                                                              0.0s
 => CACHED [build 11/17] RUN npm ci                                                                                                                                                              0.0s
 => CACHED [build 12/17] RUN npm audit fix || true                                                                                                                                               0.0s
 => ERROR [build 13/17] RUN npm run dist                                                                                                                                                        97.8s
------                                                                                                                                                                                                
 > [build 13/17] RUN npm run dist:                                                                                                                                                                    
#17 0.522                                                                                                                                                                                             
#17 0.522 > bitwarden-web@2.21.1 dist                                                                                                                                                                 
#17 0.522 > npm run build:prod && gulp postdist                                                                                                                                                       
#17 0.522                                                                                                                                                                                             
#17 0.821 
#17 0.821 > bitwarden-web@2.21.1 build:prod
#17 0.821 > gulp prebuild && cross-env NODE_ENV=production ENV=production webpack
#17 0.821 
#17 1.251 [04:12:35] Using gulpfile /vault/gulpfile.js
#17 1.255 [04:12:35] Starting 'prebuild'...
#17 1.257 [04:12:35] Starting 'clean'...
#17 1.267 [04:12:35] Finished 'clean' after 9.86 ms
#17 1.268 [04:12:35] Starting 'webfonts'...
#17 2.911 [04:12:37] Finished 'webfonts' after 1.64 s
#17 2.911 [04:12:37] Finished 'prebuild' after 1.66 s
#17 5.180 ==================================================
#17 5.180 envConfig
#17 5.180   proxyApi: https://api.bitwarden.com
#17 5.180   proxyIdentity: https://identity.bitwarden.com
#17 5.180   proxyEvents: https://events.bitwarden.com
#17 5.180   proxyNotifications: https://notifications.bitwarden.com
#17 5.180   proxyPortal: https://portal.bitwarden.com
#17 5.180   allowedHosts: 
#17 5.181 ==================================================
#17 8.235 Compiling @angular/core : module as esm2015
#17 8.288 Compiling @angular/animations : module as esm2015
#17 12.70 Compiling @angular/common : module as esm2015
#17 12.70 Compiling @angular/cdk/collections : module as esm2015
#17 12.71 Compiling @angular/animations/browser : module as esm2015
#17 13.70 Compiling @angular/platform-browser : module as esm2015
#17 13.71 Compiling ngx-infinite-scroll : module as esm5
#17 13.96 Compiling @angular/cdk/platform : module as esm2015
#17 14.47 Compiling @angular/cdk/bidi : module as esm2015
#17 14.48 Compiling @angular/platform-browser-dynamic : module as esm2015
#17 14.83 Compiling @angular/cdk/scrolling : module as esm2015
#17 15.42 Compiling angular2-toaster : module as esm2015
#17 16.03 Compiling @angular/router : module as esm2015
#17 16.21 Compiling @angular/cdk/drag-drop : module as esm2015
#17 16.36 Compiling @angular/forms : module as esm2015
#17 16.88 Compiling @angular/platform-browser/animations : module as esm2015
#17 59.06 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.07 
#17 59.07 Recommendation: math.div($spacer, 2)
#17 59.07 
#17 59.07 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.07 
#17 59.07     ╷
#17 59.07 302 │ $headings-margin-bottom:      $spacer / 2 !default;
#17 59.07     │                               ^^^^^^^^^^^
#17 59.07     ╵
#17 59.07     node_modules/bootstrap/scss/_variables.scss 302:31  @import
#17 59.07     src/scss/styles.scss 132:9                          root stylesheet
#17 59.07 
#17 59.07 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.07 
#17 59.07 Recommendation: math.div($spacer, 2)
#17 59.07 
#17 59.07 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.07 
#17 59.07     ╷
#17 59.07 302 │ $headings-margin-bottom:      $spacer / 2 !default;
#17 59.07     │                               ^^^^^^^^^^^
#17 59.07     ╵
#17 59.07     node_modules/bootstrap/scss/_variables.scss 302:31  @import
#17 59.07     src/scss/styles.scss 132:9                          @import
#17 59.07     src/connectors/webauthn.scss 1:9                    root stylesheet
#17 59.07 
#17 59.07 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.07 
#17 59.07 Recommendation: math.div($spacer, 2)
#17 59.07 
#17 59.07 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.07 
#17 59.07     ╷
#17 59.07 302 │ $headings-margin-bottom:      $spacer / 2 !default;
#17 59.07     │                               ^^^^^^^^^^^
#17 59.07     ╵
#17 59.08     node_modules/bootstrap/scss/_variables.scss 302:31  @import
#17 59.08     src/scss/styles.scss 132:9                          @import
#17 59.08     src/connectors/sso.scss 1:9                         root stylesheet
#17 59.08 
#17 59.14 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.15 
#17 59.15 Recommendation: math.div($input-padding-y, 2)
#17 59.15 
#17 59.15 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.15 
#17 59.15     ╷
#17 59.15 498 │ $input-height-inner-quarter:            add($input-line-height * .25em, $input-padding-y / 2) !default;
#17 59.15     │                                                                         ^^^^^^^^^^^^^^^^^^^^
#17 59.15     ╵
#17 59.15     node_modules/bootstrap/scss/_variables.scss 498:73  @import
#17 59.15     src/scss/styles.scss 132:9                          root stylesheet
#17 59.15 
#17 59.15 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.16 
#17 59.16 Recommendation: math.div($input-padding-y, 2)
#17 59.16 
#17 59.16 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.16 
#17 59.16     ╷
#17 59.16 498 │ $input-height-inner-quarter:            add($input-line-height * .25em, $input-padding-y / 2) !default;
#17 59.16     │                                                                         ^^^^^^^^^^^^^^^^^^^^
#17 59.16     ╵
#17 59.16     node_modules/bootstrap/scss/_variables.scss 498:73  @import
#17 59.16     src/scss/styles.scss 132:9                          @import
#17 59.16     src/connectors/webauthn.scss 1:9                    root stylesheet
#17 59.16 
#17 59.16 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.16 
#17 59.16 Recommendation: math.div($input-padding-y, 2)
#17 59.16 
#17 59.16 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.16 
#17 59.16     ╷
#17 59.16 498 │ $input-height-inner-quarter:            add($input-line-height * .25em, $input-padding-y / 2) !default;
#17 59.16     │                                                                         ^^^^^^^^^^^^^^^^^^^^
#17 59.16     ╵
#17 59.16     node_modules/bootstrap/scss/_variables.scss 498:73  @import
#17 59.16     src/scss/styles.scss 132:9                          @import
#17 59.16     src/connectors/sso.scss 1:9                         root stylesheet
#17 59.17 
#17 59.30 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.30 
#17 59.30 Recommendation: math.div($custom-control-indicator-size, 2)
#17 59.30 
#17 59.30 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.30 
#17 59.30     ╷
#17 59.30 568 │ $custom-switch-indicator-border-radius:         $custom-control-indicator-size / 2 !default;
#17 59.30     │                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#17 59.30     ╵
#17 59.31     node_modules/bootstrap/scss/_variables.scss 568:49  @import
#17 59.31     src/scss/styles.scss 132:9                          root stylesheet
#17 59.31 
#17 59.31 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.31 
#17 59.31 Recommendation: math.div($custom-control-indicator-size, 2)
#17 59.31 
#17 59.31 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.31 
#17 59.31     ╷
#17 59.31 568 │ $custom-switch-indicator-border-radius:         $custom-control-indicator-size / 2 !default;
#17 59.31     │                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#17 59.31     ╵
#17 59.31     node_modules/bootstrap/scss/_variables.scss 568:49  @import
#17 59.31     src/scss/styles.scss 132:9                          @import
#17 59.31     src/connectors/webauthn.scss 1:9                    root stylesheet
#17 59.31 
#17 59.31 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.31 
#17 59.31 Recommendation: math.div($custom-control-indicator-size, 2)
#17 59.31 
#17 59.31 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.31 
#17 59.31     ╷
#17 59.31 568 │ $custom-switch-indicator-border-radius:         $custom-control-indicator-size / 2 !default;
#17 59.31     │                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#17 59.31     ╵
#17 59.32     node_modules/bootstrap/scss/_variables.scss 568:49  @import
#17 59.32     src/scss/styles.scss 132:9                          @import
#17 59.32     src/connectors/sso.scss 1:9                         root stylesheet
#17 59.32 
#17 59.39 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.39 
#17 59.39 Recommendation: math.div($spacer, 2)
#17 59.39 
#17 59.39 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.39 
#17 59.39     ╷
#17 59.39 713 │ $nav-divider-margin-y:              $spacer / 2 !default;
#17 59.39     │                                     ^^^^^^^^^^^
#17 59.39     ╵
#17 59.39     node_modules/bootstrap/scss/_variables.scss 713:37  @import
#17 59.39     src/scss/styles.scss 132:9                          root stylesheet
#17 59.39 
#17 59.39 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.40 
#17 59.40 Recommendation: math.div($spacer, 2)
#17 59.40 
#17 59.40 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.40 
#17 59.40     ╷
#17 59.40 713 │ $nav-divider-margin-y:              $spacer / 2 !default;
#17 59.40     │                                     ^^^^^^^^^^^
#17 59.40     ╵
#17 59.40     node_modules/bootstrap/scss/_variables.scss 713:37  @import
#17 59.40     src/scss/styles.scss 132:9                          @import
#17 59.40     src/connectors/webauthn.scss 1:9                    root stylesheet
#17 59.40 
#17 59.40 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.40 
#17 59.40 Recommendation: math.div($spacer, 2)
#17 59.40 
#17 59.40 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.40 
#17 59.40     ╷
#17 59.40 713 │ $nav-divider-margin-y:              $spacer / 2 !default;
#17 59.40     │                                     ^^^^^^^^^^^
#17 59.40     ╵
#17 59.40     node_modules/bootstrap/scss/_variables.scss 713:37  @import
#17 59.40     src/scss/styles.scss 132:9                          @import
#17 59.40     src/connectors/sso.scss 1:9                         root stylesheet
#17 59.40 
#17 59.43 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.43 
#17 59.43 Recommendation: math.div($grid-gutter-width, 2)
#17 59.43 
#17 59.43 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.43 
#17 59.43     ╷
#17 59.43 847 │ $card-group-margin:                 $grid-gutter-width / 2 !default;
#17 59.43     │                                     ^^^^^^^^^^^^^^^^^^^^^^
#17 59.43     ╵
#17 59.43     node_modules/bootstrap/scss/_variables.scss 847:37  @import
#17 59.43     src/scss/styles.scss 132:9                          root stylesheet
#17 59.43 
#17 59.43 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.43 
#17 59.43 Recommendation: math.div($grid-gutter-width, 2)
#17 59.43 
#17 59.43 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.43 
#17 59.43     ╷
#17 59.43 847 │ $card-group-margin:                 $grid-gutter-width / 2 !default;
#17 59.43     │                                     ^^^^^^^^^^^^^^^^^^^^^^
#17 59.43     ╵
#17 59.44     node_modules/bootstrap/scss/_variables.scss 847:37  @import
#17 59.44     src/scss/styles.scss 132:9                          @import
#17 59.44     src/connectors/webauthn.scss 1:9                    root stylesheet
#17 59.44 
#17 59.44 DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
#17 59.44 
#17 59.44 Recommendation: math.div($grid-gutter-width, 2)
#17 59.44 
#17 59.44 More info and automated migrator: https://sass-lang.com/d/slash-div
#17 59.44 
#17 59.44     ╷
#17 59.44 847 │ $card-group-margin:                 $grid-gutter-width / 2 !default;
#17 59.44     │                                     ^^^^^^^^^^^^^^^^^^^^^^
#17 59.44     ╵
#17 59.44     node_modules/bootstrap/scss/_variables.scss 847:37  @import
#17 59.44     src/scss/styles.scss 132:9                          @import
#17 59.44     src/connectors/sso.scss 1:9                         root stylesheet
#17 59.44 
#17 67.77 WARNING: 71 repetitive deprecation warnings omitted.
#17 67.77 
#17 68.22 WARNING: 71 repetitive deprecation warnings omitted.
#17 68.22 
#17 68.51 WARNING: 71 repetitive deprecation warnings omitted.
#17 68.51 
------
executor failed running [/bin/sh -c npm run dist]: exit code: 1
```
