### PR TITLE
Fix org vault trash cleanup warning

### DIFF
--- a/patches/v2.23.0.patch
+++ b/patches/v2.23.0.patch
@@ -116,6 +116,21 @@ index 216c1d91..73e82119 100644
          }
      }
  
+diff --git a/src/app/organizations/vault/vault.component.ts b/src/app/organizations/vault/vault.component.ts
+index 4d98e38a..a52f68c7 100644
+--- a/src/app/organizations/vault/vault.component.ts
++++ b/src/app/organizations/vault/vault.component.ts
+@@ -61,9 +61,7 @@ export class VaultComponent implements OnInit, OnDestroy {
+         private platformUtilsService: PlatformUtilsService) { }
+ 
+     ngOnInit() {
+-        this.trashCleanupWarning = this.i18nService.t(
+-            this.platformUtilsService.isSelfHost() ? 'trashCleanupWarningSelfHosted' : 'trashCleanupWarning'
+-        );
++        this.trashCleanupWarning = this.i18nService.t('trashCleanupWarningSelfHosted');
+ 
+         const queryParams = this.route.parent.params.subscribe(async params => {
+             this.organization = await this.userService.getOrganization(params.organizationId);
 diff --git a/src/app/send/access.component.html b/src/app/send/access.component.html
 index 84944a2b..107ad359 100644
 --- a/src/app/send/access.component.html


### PR DESCRIPTION
This should match the self-hosted personal vault warning, which doesn't
give a specific number of days for when trashed items are auto-deleted.

Before:

![trash-before](https://user-images.githubusercontent.com/203380/138258796-e9b79783-bcf2-4cce-8896-9a6492f8a2ea.png)

After:

![trash-after](https://user-images.githubusercontent.com/203380/138258815-7164ecbb-f07f-4f20-a461-47f787ab3b2d.png)