### PR TITLE
Update web-vault to v2022.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 # Compile the web vault using docker
 # Usage:
+#    Quick and easy:
+#    `make docker-extract`
+#    or, if you just want to build
+#    `make docker`
+#
 #    docker build -t web_vault_build .
 #    image_id=$(docker create web_vault_build)
 #    docker cp $image_id:/bw_web_vault.tar.gz .
@@ -21,10 +26,10 @@ RUN chown node:node /vault
 USER node
 
 # Can be a tag, release, but prefer a commit hash because it's not changeable
-# https://github.com/bitwarden/web/commit/${VAULT_VERSION}
+# https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/bitwarden/web/releases/tag/v2022.6.0
-ARG VAULT_VERSION=bb5f9311a776b94a33bcf0a7bff44cd87a2fcc92
+# Using https://github.com/bitwarden/clients/releases/tag/web-v2022.6.2
+ARG VAULT_VERSION=c0cb88a733c677fae84e517fbc63d7d16cb912c2
 
 RUN git clone https://github.com/bitwarden/clients.git /vault
 WORKDIR /vault

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := bash
 .DELETE_ON_ERROR:
 
 help:
-	@echo "Use either: clean, checkout, build, patch-web-vault, generate-patch, tar, or full"
+	@echo "Use either: clean, checkout, patch-web-vault, generate-patch, build, tar, or full"
 	@echo "Or for docker builds use: docker or docker-extract"
 .PHONY: help
 

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -19,6 +19,15 @@ if [[ -z "$VAULT_VERSION" ]]; then
     VAULT_VERSION="${input}"
 fi
 
+# Check the format of the provided vault version
+# If this is vYYYY.M.B or YYYY.M.B then fix this automatically to prepend web- or web-v
+if [[ "${VAULT_VERSION}" =~ ^20[0-9]{2}\.[0-9]{1,2}.[0-9]{1} ]]; then
+    VAULT_VERSION="web-v${VAULT_VERSION}"
+elif [[ "${VAULT_VERSION}" =~ ^v20[0-9]{2}\.[0-9]{1,2}.[0-9]{1} ]]; then
+    VAULT_VERSION="web-${VAULT_VERSION}"
+fi
+echo "Using: '${VAULT_VERSION}' to checkout bitwarden/client."
+
 if [ ! -d "${VAULT_FOLDER}" ]; then
     # If this is the first time, clone the project
     git clone https://github.com/bitwarden/clients.git "${VAULT_FOLDER}"


### PR DESCRIPTION
- Updated to the latest released web-vault.
- Made some small changes to the checkout script to catch tags like
  `2022.6.2` and `v2022.6.2` and convert them to `web-v2022.6.2` instead.