### PR TITLE
exclude package-lock.json from generated patches

### DIFF
--- a/scripts/generate_patch_file.sh
+++ b/scripts/generate_patch_file.sh
@@ -23,7 +23,7 @@ fi
 PATCH_FILENAME="${VAULT_VERSION}.patch"
 
 if [ "$(git status --porcelain | wc -l)" -ge 1 ]; then
-    git --no-pager diff --no-color --minimal > "../patches/${PATCH_FILENAME}"
+    git --no-pager diff --no-color --minimal -- . ':!package-lock.json' > "../patches/${PATCH_FILENAME}"
     echo "Patch has been created here: patches/${PATCH_FILENAME}"
 else
     echo "No changes found, skip generating a patch file."


### PR DESCRIPTION
`make generate-patch` should not include changes to `package-lock.json`.