### PR TITLE
make build a phony target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ generate-patch:
 
 build:
 	./scripts/build_web_vault.sh
-.PHONY: checkout
+.PHONY: build
 
 tar:
 	./scripts/tar_web_vault.sh


### PR DESCRIPTION
The [`.PHONY`](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html) for build was misnamed.