### PR TITLE
don't stash the node_modules folder

### DIFF
--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -35,7 +35,7 @@ else
     # If there already is a checked-out repo, lets clean it up first.
     pushd "${VAULT_FOLDER}"
         # Stash current changes if there are any, we don't want to loose our work if we had some
-        git stash --all --quiet &> /dev/null || true
+        git stash --include-untracked --quiet &> /dev/null || true
         # Checkout the master repo first
         git checkout master
         git reset --hard


### PR DESCRIPTION
I was wondering why `make checkout` always takes so long and it's because we are using `git stash --all` which stashes also ignored files, i.d. the `node_modules` folder, too. Not sure if this is necessary, since we use `npm ci` to build the web-vault so we don't really need to stash it, because it will always [start with a clean build](https://docs.npmjs.com/cli/v8/commands/npm-ci) anyway.
