### PR TITLE
update web-vault to v2023.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ USER node
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/bitwarden/clients/releases/tag/web-v2022.12.0
-ARG VAULT_VERSION=18919150aa49d95f0131c82af6eb9c0745c2ad36
+# Using https://github.com/bitwarden/clients/releases/tag/web-v2023.1.0
+ARG VAULT_VERSION=0b814ba86355345848c20e2c46711ea13436ac19
 
 WORKDIR /vault
 RUN git init

--- a/patches/v2023.1.0.patch
+++ b/patches/v2023.1.0.patch
@@ -256,6 +256,19 @@ index 652ee24a1..5a63562cc 100644
          size: 160,
        });
      }, 100);
+diff --git a/apps/web/src/app/tools/generator.component.ts b/apps/web/src/app/tools/generator.component.ts
+index 6a5f00c19..1bf8daf31 100644
+--- a/apps/web/src/app/tools/generator.component.ts
++++ b/apps/web/src/app/tools/generator.component.ts
+@@ -40,7 +40,7 @@ export class GeneratorComponent extends BaseGeneratorComponent {
+       route,
+       window
+     );
+-    if (platformUtilsService.isSelfHost()) {
++    if (true) {
+       // Cannot use Firefox Relay on self hosted web vaults due to CORS issues with Firefox Relay API
+       this.forwardOptions.splice(
+         this.forwardOptions.findIndex((o) => o.value === "firefoxrelay"),
 diff --git a/apps/web/src/app/vault/vault.component.ts b/apps/web/src/app/vault/vault.component.ts
 index 4113b3ab2..7a8227232 100644
 --- a/apps/web/src/app/vault/vault.component.ts
@@ -358,12 +371,6 @@ index 0003f521c..41d6fca76 100644
 +app-org-account > div.secondary-header:nth-child(3) { @extend %vw-hide; }
 +app-org-account > div.secondary-header:nth-child(3) + p { @extend %vw-hide; }
 +app-org-account > div.secondary-header:nth-child(3) + p + form { @extend %vw-hide; }
-+
-+/* Hide Firefox Relay - It is CORS protected for SaaS only */
-+#forwardtype_firefoxrelay, label[for^=forwardtype_firefoxrelay] { @extend %vw-hide; }
-+
-+/* Hide DuckDuckGo - It does not work for self-hosted either. */
-+#forwardtype_duckduckgo, label[for^=forwardtype_duckduckgo] { @extend %vw-hide; }
 +
 +/* Hide Device Verification form at the Two Step Login screen */
 +app-security > app-two-factor-setup > form { @extend %vw-hide; }

--- a/patches/v2023.1.0.patch
+++ b/patches/v2023.1.0.patch
@@ -1,0 +1,419 @@
+diff --git a/apps/web/src/404.html b/apps/web/src/404.html
+index 5a650b367..275c34f72 100644
+--- a/apps/web/src/404.html
++++ b/apps/web/src/404.html
+@@ -28,7 +28,7 @@
+       <div class="container inner banner">
+         <div class="row align-items-center">
+           <div class="col brand">
+-            <i class="bwi bwi-shield"></i>&nbsp; <strong>bit</strong>warden
++            <i class="bwi bwi-shield"></i>&nbsp; <strong>Vault</strong>warden
+           </div>
+         </div>
+       </div>
+@@ -42,11 +42,10 @@
+         </a>
+       </p>
+       <p>
+-        You can <a href="/">return to the web vault</a>, check our
+-        <a href="https://status.bitwarden.com/">status page</a> or
+-        <a href="https://bitwarden.com/contact/">contact us</a>.
++        You can <a href="/">return to the web vault</a>, or
++        <a href="https://github.com/dani-garcia/vaultwarden">contact us</a>.
+       </p>
+     </div>
+-    <div class="container footer text-muted content">© Copyright 2023 Bitwarden, Inc.</div>
++    <div class="container footer text-muted content">Vaultwarden (unofficial Bitwarden&reg; server)</div>
+   </body>
+ </html>
+diff --git a/apps/web/src/app/app.component.ts b/apps/web/src/app/app.component.ts
+index 12f499a01..68250d53c 100644
+--- a/apps/web/src/app/app.component.ts
++++ b/apps/web/src/app/app.component.ts
+@@ -172,6 +172,10 @@ export class AppComponent implements OnDestroy, OnInit {
+             break;
+           }
+           case "showToast":
++            if (typeof message.text === "string" && typeof crypto.subtle === 'undefined') {
++              message.title="This browser requires HTTPS to use the web vault";
++              message.text="Check the Vaultwarden wiki for details on how to enable it";
++            }
+             this.showToast(message);
+             break;
+           case "setFullWidth":
+diff --git a/apps/web/src/app/core/init.service.ts b/apps/web/src/app/core/init.service.ts
+index 8baa7c0dd..8f3b5d464 100644
+--- a/apps/web/src/app/core/init.service.ts
++++ b/apps/web/src/app/core/init.service.ts
+@@ -37,11 +37,23 @@ export class InitService {
+   ) {}
+ 
+   init() {
++    function getBaseUrl() {
++      // If the base URL is `https://vaultwarden.example.com/base/path/`,
++      // `window.location.href` should have one of the following forms:
++      //
++      // - `https://vaultwarden.example.com/base/path/`
++      // - `https://vaultwarden.example.com/base/path/#/some/route[?queryParam=...]`
++      //
++      // We want to get to just `https://vaultwarden.example.com/base/path`.
++      let baseUrl = window.location.href;
++      baseUrl = baseUrl.replace(/#.*/, '');  // Strip off `#` and everything after.
++      baseUrl = baseUrl.replace(/\/+$/, ''); // Trim any trailing `/` chars.
++      return baseUrl;
++    }
+     return async () => {
+       await this.stateService.init();
+ 
+-      const urls = process.env.URLS as Urls;
+-      urls.base ??= this.win.location.origin;
++      const urls = {base: getBaseUrl()};
+       this.environmentService.setUrls(urls);
+ 
+       setTimeout(() => this.notificationsService.init(), 3000);
+diff --git a/apps/web/src/app/core/router.service.ts b/apps/web/src/app/core/router.service.ts
+index aa9041875..680936375 100644
+--- a/apps/web/src/app/core/router.service.ts
++++ b/apps/web/src/app/core/router.service.ts
+@@ -23,7 +23,7 @@ export class RouterService {
+       .subscribe((event: NavigationEnd) => {
+         this.currentUrl = event.url;
+ 
+-        let title = i18nService.t("pageTitle", "Bitwarden");
++        let title = i18nService.t("pageTitle", "Vaultwarden");
+         let child = this.activatedRoute.firstChild;
+         while (child.firstChild) {
+           child = child.firstChild;
+diff --git a/apps/web/src/app/core/web-platform-utils.service.ts b/apps/web/src/app/core/web-platform-utils.service.ts
+index 2d682a35a..e64687b67 100644
+--- a/apps/web/src/app/core/web-platform-utils.service.ts
++++ b/apps/web/src/app/core/web-platform-utils.service.ts
+@@ -194,11 +194,11 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
+   }
+ 
+   isDev(): boolean {
+-    return process.env.NODE_ENV === "development";
++    return false;
+   }
+ 
+   isSelfHost(): boolean {
+-    return process.env.ENV.toString() === "selfhosted";
++    return false;
+   }
+ 
+   copyToClipboard(text: string, options?: any): void | boolean {
+diff --git a/apps/web/src/app/layouts/footer.component.html b/apps/web/src/app/layouts/footer.component.html
+index 98836bfd5..1239167c4 100644
+--- a/apps/web/src/app/layouts/footer.component.html
++++ b/apps/web/src/app/layouts/footer.component.html
+@@ -1,6 +1,6 @@
+ <div class="container footer text-muted">
+   <div class="row">
+-    <div class="col">&copy; {{ year }} Bitwarden Inc.</div>
++    <div class="col">Vaultwarden (unofficial Bitwarden&reg; server)</div>
+     <div class="col text-center"></div>
+     <div class="col text-right">
+       {{ "versionNumber" | i18n: version }}
+diff --git a/apps/web/src/app/layouts/frontend-layout.component.html b/apps/web/src/app/layouts/frontend-layout.component.html
+index d737bc9f0..6a312c0b1 100644
+--- a/apps/web/src/app/layouts/frontend-layout.component.html
++++ b/apps/web/src/app/layouts/frontend-layout.component.html
+@@ -1,5 +1,5 @@
+ <router-outlet></router-outlet>
+ <div class="container my-5 text-muted text-center">
+-  &copy; {{ year }} Bitwarden Inc. <br />
++  Vaultwarden (unofficial Bitwarden&reg; server)<br />
+   {{ "versionNumber" | i18n: version }}
+ </div>
+diff --git a/apps/web/src/app/layouts/navbar.component.html b/apps/web/src/app/layouts/navbar.component.html
+index e1513f050..2e854c3ba 100644
+--- a/apps/web/src/app/layouts/navbar.component.html
++++ b/apps/web/src/app/layouts/navbar.component.html
+@@ -1,6 +1,6 @@
+ <nav class="navbar navbar-expand navbar-dark" [ngClass]="{ 'nav-background-alt': selfHosted }">
+   <div class="container">
+-    <a class="navbar-brand" routerLink="/" appA11yTitle="{{ 'pageTitle' | i18n: 'Bitwarden' }}">
++    <a class="navbar-brand" routerLink="/" appA11yTitle="{{ 'pageTitle' | i18n: 'Vaultwarden' }}">
+       <i class="bwi bwi-shield" aria-hidden="true"></i>
+     </a>
+     <div class="collapse navbar-collapse">
+@@ -68,7 +68,7 @@
+               <i class="bwi bwi-fw bwi-user" aria-hidden="true"></i>
+               {{ "accountSettings" | i18n }}
+             </a>
+-            <a bitMenuItem href="https://bitwarden.com/help/" target="_blank" rel="noopener">
++            <a bitMenuItem href="https://github.com/dani-garcia/vaultwarden/" target="_blank" rel="noopener">
+               <i class="bwi bwi-fw bwi-question-circle" aria-hidden="true"></i>
+               {{ "getHelp" | i18n }}
+             </a>
+diff --git a/apps/web/src/app/organizations/create/organization-information.component.html b/apps/web/src/app/organizations/create/organization-information.component.html
+index 6029cfd83..04324b7d1 100644
+--- a/apps/web/src/app/organizations/create/organization-information.component.html
++++ b/apps/web/src/app/organizations/create/organization-information.component.html
+@@ -12,7 +12,7 @@
+       <input bitInput type="text" formControlName="name" />
+     </bit-form-field>
+     <bit-form-field class="tw-w-1/2">
+-      <bit-label>{{ "billingEmail" | i18n }}</bit-label>
++      <bit-label>{{ "email" | i18n }}</bit-label>
+       <input bitInput type="email" formControlName="billingEmail" />
+     </bit-form-field>
+     <bit-form-field class="tw-w-1/2" *ngIf="isProvider">
+diff --git a/apps/web/src/app/organizations/settings/account.component.html b/apps/web/src/app/organizations/settings/account.component.html
+index 1d11412bf..c7911e418 100644
+--- a/apps/web/src/app/organizations/settings/account.component.html
++++ b/apps/web/src/app/organizations/settings/account.component.html
+@@ -30,7 +30,7 @@
+         />
+       </div>
+       <div class="form-group">
+-        <label for="billingEmail">{{ "billingEmail" | i18n }}</label>
++        <label for="billingEmail">{{ "email" | i18n }}</label>
+         <input
+           id="billingEmail"
+           class="form-control"
+diff --git a/apps/web/src/app/organizations/vault/vault.component.ts b/apps/web/src/app/organizations/vault/vault.component.ts
+index c175e42d7..25a3db231 100644
+--- a/apps/web/src/app/organizations/vault/vault.component.ts
++++ b/apps/web/src/app/organizations/vault/vault.component.ts
+@@ -81,11 +81,7 @@ export class VaultComponent implements OnInit, OnDestroy {
+   ) {}
+ 
+   ngOnInit() {
+-    this.trashCleanupWarning = this.i18nService.t(
+-      this.platformUtilsService.isSelfHost()
+-        ? "trashCleanupWarningSelfHosted"
+-        : "trashCleanupWarning"
+-    );
++    this.trashCleanupWarning = this.i18nService.t("trashCleanupWarningSelfHosted");
+     // eslint-disable-next-line rxjs-angular/prefer-takeuntil, rxjs/no-async-subscribe
+     this.route.parent.params.subscribe(async (params: any) => {
+       this.organization = await this.organizationService.get(params.organizationId);
+diff --git a/apps/web/src/app/send/access.component.html b/apps/web/src/app/send/access.component.html
+index 91ae288d3..2310805ca 100644
+--- a/apps/web/src/app/send/access.component.html
++++ b/apps/web/src/app/send/access.component.html
+@@ -137,15 +137,6 @@
+     <div class="col-12 text-center mt-5 text-muted">
+       <p class="mb-0">
+         {{ "sendAccessTaglineProductDesc" | i18n }}<br />
+-        {{ "sendAccessTaglineLearnMore" | i18n }}
+-        <a href="https://www.bitwarden.com/products/send?source=web-vault" target="_blank"
+-          >Bitwarden Send</a
+-        >
+-        {{ "sendAccessTaglineOr" | i18n }}
+-        <a href="https://vault.bitwarden.com/#/register" target="_blank">{{
+-          "sendAccessTaglineSignUp" | i18n
+-        }}</a>
+-        {{ "sendAccessTaglineTryToday" | i18n }}
+       </p>
+     </div>
+   </div>
+diff --git a/apps/web/src/app/settings/billing-history-view.component.ts b/apps/web/src/app/settings/billing-history-view.component.ts
+index 4a2ff349a..c8090b08e 100644
+--- a/apps/web/src/app/settings/billing-history-view.component.ts
++++ b/apps/web/src/app/settings/billing-history-view.component.ts
+@@ -34,7 +34,7 @@ export class BillingHistoryViewComponent implements OnInit {
+       return;
+     }
+     this.loading = true;
+-    this.billing = await this.apiService.getUserBillingHistory();
++    this.billing = null;
+     this.loading = false;
+   }
+ }
+diff --git a/apps/web/src/app/settings/settings.component.ts b/apps/web/src/app/settings/settings.component.ts
+index 2a2fc4d27..26053e486 100644
+--- a/apps/web/src/app/settings/settings.component.ts
++++ b/apps/web/src/app/settings/settings.component.ts
+@@ -55,10 +55,6 @@ export class SettingsComponent implements OnInit, OnDestroy {
+     this.hasFamilySponsorshipAvailable = await this.organizationService.canManageSponsorships();
+     const hasPremiumFromOrg = await this.stateService.getHasPremiumFromOrganization();
+     let billing = null;
+-    if (!this.selfHosted) {
+-      billing = await this.apiService.getUserBillingHistory();
+-    }
+-    this.hideSubscription =
+-      !this.premium && hasPremiumFromOrg && (this.selfHosted || billing?.hasNoHistory);
++    this.hideSubscription = true;
+   }
+ }
+diff --git a/apps/web/src/app/settings/two-factor-authenticator.component.ts b/apps/web/src/app/settings/two-factor-authenticator.component.ts
+index 652ee24a1..5a63562cc 100644
+--- a/apps/web/src/app/settings/two-factor-authenticator.component.ts
++++ b/apps/web/src/app/settings/two-factor-authenticator.component.ts
+@@ -98,11 +98,11 @@ export class TwoFactorAuthenticatorComponent
+       new window.QRious({
+         element: document.getElementById("qr"),
+         value:
+-          "otpauth://totp/Bitwarden:" +
++          "otpauth://totp/Vaultwarden:" +
+           encodeURIComponent(email) +
+           "?secret=" +
+           encodeURIComponent(this.key) +
+-          "&issuer=Bitwarden",
++          "&issuer=Vaultwarden",
+         size: 160,
+       });
+     }, 100);
+diff --git a/apps/web/src/app/vault/vault.component.ts b/apps/web/src/app/vault/vault.component.ts
+index 4113b3ab2..7a8227232 100644
+--- a/apps/web/src/app/vault/vault.component.ts
++++ b/apps/web/src/app/vault/vault.component.ts
+@@ -91,11 +91,7 @@ export class VaultComponent implements OnInit, OnDestroy {
+   async ngOnInit() {
+     this.showVerifyEmail = !(await this.tokenService.getEmailVerified());
+     this.showBrowserOutdated = window.navigator.userAgent.indexOf("MSIE") !== -1;
+-    this.trashCleanupWarning = this.i18nService.t(
+-      this.platformUtilsService.isSelfHost()
+-        ? "trashCleanupWarningSelfHosted"
+-        : "trashCleanupWarning"
+-    );
++    this.trashCleanupWarning = this.i18nService.t("trashCleanupWarningSelfHosted");
+ 
+     // eslint-disable-next-line rxjs-angular/prefer-takeuntil, rxjs/no-async-subscribe
+     this.route.queryParams.pipe(first()).subscribe(async (params) => {
+diff --git a/apps/web/src/index.html b/apps/web/src/index.html
+index 63d4e72c0..68b6ada00 100644
+--- a/apps/web/src/index.html
++++ b/apps/web/src/index.html
+@@ -5,7 +5,7 @@
+     <meta name="viewport" content="width=1010" />
+     <meta name="theme-color" content="#175DDC" />
+ 
+-    <title page-title>Bitwarden Web Vault</title>
++    <title page-title>Vaultwarden Web Vault</title>
+ 
+     <link rel="apple-touch-icon" sizes="180x180" href="images/icons/apple-touch-icon.png" />
+     <link rel="icon" type="image/png" sizes="32x32" href="images/icons/favicon-32x32.png" />
+diff --git a/apps/web/src/manifest.json b/apps/web/src/manifest.json
+index 92a1204c6..5a10dc9ae 100644
+--- a/apps/web/src/manifest.json
++++ b/apps/web/src/manifest.json
+@@ -1,5 +1,5 @@
+ {
+-  "name": "Bitwarden Vault",
++  "name": "Vaultwarden Web Vault",
+   "icons": [
+     {
+       "src": "images/icons/android-chrome-192x192.png",
+@@ -12,6 +12,6 @@
+       "type": "image/png"
+     }
+   ],
+-  "theme_color": "#175DDC",
+-  "background_color": "#175DDC"
++  "theme_color": "#ffffff",
++  "background_color": "#ffffff"
+ }
+diff --git a/apps/web/src/scss/styles.scss b/apps/web/src/scss/styles.scss
+index 0003f521c..41d6fca76 100644
+--- a/apps/web/src/scss/styles.scss
++++ b/apps/web/src/scss/styles.scss
+@@ -58,3 +58,68 @@
+ @import "./tables";
+ @import "./toasts";
+ @import "./vault-filters";
++
++/**** START Vaultwarden CHANGES ****/
++/* This combines all selectors extending it into one */
++%vw-hide { display: none !important; }
++
++/* This allows searching for the combined style in the browsers dev-tools (look into the head tag) */
++#vw-hide,head { @extend %vw-hide; }
++
++/* Hide the Billing Page tab */
++bit-tab-link[route="billing"] { @extend %vw-hide; }
++
++/* Hide any link pointing to Free Bitwarden Families */
++a[href$="/settings/sponsored-families"] { @extend %vw-hide; }
++
++/* Hide the `Enterprise Single Sign-On` button on the login page */
++a[href$="/sso"] { @extend %vw-hide; }
++
++/* Hide Two-Factor menu in Organization settings */
++app-org-settings a[href$="/settings/two-factor"] { @extend %vw-hide; }
++
++/* Hide Business Owned checkbox */
++app-org-info > form:nth-child(1) > div:nth-child(3) { @extend %vw-hide; }
++
++/* Hide organization plans */
++app-organization-plans > form > div.form-check { @extend %vw-hide; }
++app-organization-plans > form > h2.mt-5 { @extend %vw-hide; }
++
++/* Hide the `This account is owned by a business` checkbox and label */
++#ownedBusiness, label[for^=ownedBusiness] { @extend %vw-hide; }
++
++/* Hide External Id field for Collections */
++app-collection-add-edit form div.form-group:nth-child(2) { @extend %vw-hide; }
++
++/* Hide the radio button and label for the `Custom` org user type */
++#userTypeCustom, label[for^=userTypeCustom] { @extend %vw-hide; }
++
++/* Hide Business Name and Identifier */
++app-org-account form div.form-group:nth-child(3) { @extend %vw-hide; }
++app-org-account form div.form-group:nth-child(4) { @extend %vw-hide; }
++
++/* Hide Tax Info and Form in Organization settings */
++app-org-account > div.secondary-header:nth-child(3) { @extend %vw-hide; }
++app-org-account > div.secondary-header:nth-child(3) + p { @extend %vw-hide; }
++app-org-account > div.secondary-header:nth-child(3) + p + form { @extend %vw-hide; }
++
++/* Hide Firefox Relay - It is CORS protected for SaaS only */
++#forwardtype_firefoxrelay, label[for^=forwardtype_firefoxrelay] { @extend %vw-hide; }
++
++/* Hide DuckDuckGo - It does not work for self-hosted either. */
++#forwardtype_duckduckgo, label[for^=forwardtype_duckduckgo] { @extend %vw-hide; }
++
++/* Hide Device Verification form at the Two Step Login screen */
++app-security > app-two-factor-setup > form { @extend %vw-hide; }
++
++/* Replace the Bitwarden Shield at the top left with a Vaultwarden icon */
++.bwi-shield:before {
++  content: '' !important;
++  width: 32px !important;
++  height: 40px !important;
++  display: block !important;
++  background-image: url(../images/icon-white.png) !important;
++  background-repeat: no-repeat;
++  background-position-y: bottom;
++}
++/**** END Vaultwarden CHANGES ****/
+diff --git a/libs/angular/src/components/register.component.ts b/libs/angular/src/components/register.component.ts
+index 029639e7e..6c3606341 100644
+--- a/libs/angular/src/components/register.component.ts
++++ b/libs/angular/src/components/register.component.ts
+@@ -35,7 +35,7 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
+   showPassword = false;
+   formPromise: Promise<RegisterResponse>;
+   referenceData: ReferenceEventRequest;
+-  showTerms = true;
++  showTerms = false;
+   showErrorSummary = false;
+   passwordStrengthResult: any;
+   color: string;
+@@ -88,7 +88,7 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
+     protected logService: LogService
+   ) {
+     super(environmentService, i18nService, platformUtilsService);
+-    this.showTerms = !platformUtilsService.isSelfHost();
++    this.showTerms = false;
+   }
+ 
+   async ngOnInit() {
+@@ -96,6 +96,15 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
+   }
+ 
+   async submit(showToast = true) {
++    if (typeof crypto.subtle === 'undefined') {
++      this.platformUtilsService.showToast(
++        "error",
++        "This browser requires HTTPS to use the web vault",
++        "Check the Vaultwarden wiki for details on how to enable it"
++      );
++      return;
++    }
++
+     let email = this.formGroup.value.email;
+     email = email.trim().toLowerCase();
+     let name = this.formGroup.value.name;


### PR DESCRIPTION
There has been a new release: [web-v2023.1.0](https://github.com/bitwarden/clients/releases/tag/web-v2023.1.0)

Also hide duckduckgo and firefox relay again from the username generator (as that has been changed in the recent releases).