### PR TITLE
Make scripts compatible with macOS/BSD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ WORKDIR /vault/apps/web
 RUN npm run dist:oss:selfhost
 
 RUN printf '{"version":"%s"}' \
-      $(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/dani-garcia/bw_web_builds.git 'v*' | tail -n1 | sed -E 's#.*?refs/tags/v##') \
+      $(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/dani-garcia/bw_web_builds.git 'v*' | tail -n1 | grep -Eo '[^\/]*$') \
       > build/vw-version.json
 
 # Delete debugging map files, optional

--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -10,7 +10,7 @@ if [[ -z ${PATCH_NAME} ]]; then
     else
         echo "Patch file not found, using latest"
         # If not, use the latest one
-        PATCH_NAME="$(find ../patches -printf "%f\\n" | sort -V | tail -n1)"
+        PATCH_NAME="$(find ../patches -type f -print0 | xargs -0 basename -a | sort -V | tail -n1)"
     fi
 fi
 

--- a/scripts/build_web_vault.sh
+++ b/scripts/build_web_vault.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -o pipefail -o errexit
-BASEDIR=$(dirname "$(readlink -f "$0")")
+BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
 # Error handling
 handle_error() {
@@ -30,7 +30,7 @@ npm run dist:oss:selfhost
 
 # Create vw-version.json with the latest tag from the remote repo.
 printf '{"version":"%s"}' \
-      "$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/dani-garcia/bw_web_builds.git 'v*' | tail -n1 | sed -E 's#.*?refs/tags/v##')" \
+      "$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/dani-garcia/bw_web_builds.git 'v*' | tail -n1 | grep -Eo '[^\/]*$')" \
       > build/vw-version.json
 
 popd

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -o pipefail -o errexit
-BASEDIR=$(dirname "$(readlink -f "$0")")
+BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
 # Error handling
 handle_error() {

--- a/scripts/generate_patch_file.sh
+++ b/scripts/generate_patch_file.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -o pipefail -o errexit
-BASEDIR=$(dirname "$(readlink -f "$0")")
+BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
 # Error handling
 handle_error() {

--- a/scripts/package_web_vault.sh
+++ b/scripts/package_web_vault.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -o pipefail -o errexit
-BASEDIR=$(dirname "$(readlink -f "$0")")
+BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
 handle_error() {
     read -n1 -r -p "FAILED: line $1, exit code $2. Press any key to exit..." _

--- a/scripts/patch_web_vault.sh
+++ b/scripts/patch_web_vault.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -o pipefail -o errexit
-BASEDIR=$(dirname "$(readlink -f "$0")")
+BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
All the scripts used by this repo were more focused on Linux based systems. They did not work on macOS or other BSD based systems because of flags or commands which are not available.

This PR resolves those items by adjusting the failed commands so they work on both Linux and macOS/BSD systems.

Fixes #112