### PR TITLE
hide sso login link again

### DIFF
--- a/patches/v2023.3.0.patch
+++ b/patches/v2023.3.0.patch
@@ -326,7 +326,7 @@ index 92a1204c60..5a10dc9ae9 100644
 +  "background_color": "#ffffff"
  }
 diff --git a/apps/web/src/scss/styles.scss b/apps/web/src/scss/styles.scss
-index 0003f521c7..9470f0aa37 100644
+index 0003f521c7..32ecf5112e 100644
 --- a/apps/web/src/scss/styles.scss
 +++ b/apps/web/src/scss/styles.scss
 @@ -58,3 +58,62 @@
@@ -348,7 +348,7 @@ index 0003f521c7..9470f0aa37 100644
 +a[href$="/settings/sponsored-families"] { @extend %vw-hide; }
 +
 +/* Hide the `Enterprise Single Sign-On` button on the login page */
-+a[href$="/sso"] { @extend %vw-hide; }
++a[routerlink="/sso"] { @extend %vw-hide; }
 +
 +/* Hide Two-Factor menu in Organization settings */
 +app-org-settings a[href$="/settings/two-factor"] { @extend %vw-hide; }


### PR DESCRIPTION
On the login page the current CSS rule `a[href$="/sso"]` for hiding the Enterprise single sign-on button does not match anymore because the email gets added to the end like so `#/sso?email=<email>`:
![vaultwarden-login-sso-button](https://user-images.githubusercontent.com/509385/227743712-7a1dc4e5-9bc6-4088-af93-55cda3575b7a.png)


By targeting the `routerlink="/sso"` attribute instead the button should stay hidden again.