### PR TITLE
Support annotated tags and update web-vault to web-v2023.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ USER node
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/bitwarden/clients/releases/tag/web-v2023.4.1
-ARG VAULT_VERSION=4f4715fd0d7fc2e224a5efd5c6f8ce942922f067
+# Using https://github.com/bitwarden/clients/releases/tag/web-v2023.4.2
+ARG VAULT_VERSION=b416432bce79cf6ee99adb908a5a26b66bb7869b
 
 WORKDIR /vault
 RUN git init

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ WORKDIR /vault/apps/web
 RUN npm run dist:oss:selfhost
 
 RUN printf '{"version":"%s"}' \
-      $(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/dani-garcia/bw_web_builds.git 'v*' | tail -n1 | grep -Eo '[^\/v]*$') \
+      $(git -c 'versionsort.suffix=-' ls-remote --tags --refs --sort='v:refname' https://github.com/dani-garcia/bw_web_builds.git 'v*' | tail -n1 | grep -Eo '[^\/v]*$') \
       > build/vw-version.json
 
 # Delete debugging map files, optional

--- a/scripts/build_web_vault.sh
+++ b/scripts/build_web_vault.sh
@@ -30,7 +30,7 @@ npm run dist:oss:selfhost
 
 # Create vw-version.json with the latest tag from the remote repo.
 printf '{"version":"%s"}' \
-      "$(git -c 'versionsort.suffix=-' ls-remote --tags --sort='v:refname' https://github.com/dani-garcia/bw_web_builds.git 'v*' | tail -n1 | grep -Eo '[^\/v]*$')" \
+      "$(git -c 'versionsort.suffix=-' ls-remote --tags --refs --sort='v:refname' https://github.com/dani-garcia/bw_web_builds.git 'v*' | tail -n1 | grep -Eo '[^\/v]*$')" \
       > build/vw-version.json
 
 popd


### PR DESCRIPTION
As discussed in #126 there is currently an issue with creating the version string from annotated tags.

Also update to latest web-vault release: [web-v2023.4.2](https://github.com/bitwarden/clients/releases/tag/web-v2023.4.2)