### PR TITLE
add "web vault" to clarify version number in footer

### DIFF
--- a/patches/v2023.5.1.patch
+++ b/patches/v2023.5.1.patch
@@ -168,19 +168,22 @@ index 7b9a7b9477..1a26e31160 100644
  
    copyToClipboard(text: string, options?: any): void | boolean {
 diff --git a/apps/web/src/app/layouts/footer.component.html b/apps/web/src/app/layouts/footer.component.html
-index 8cacb4ceba..37d7cfb031 100644
+index 8cacb4ceba..eee2728221 100644
 --- a/apps/web/src/app/layouts/footer.component.html
 +++ b/apps/web/src/app/layouts/footer.component.html
-@@ -1,6 +1,6 @@
+@@ -1,8 +1,9 @@
  <div class="container footer text-muted">
    <div class="row">
 -    <div class="col">&copy; {{ year }} Bitwarden Inc.</div>
 +    <div class="col">Vaultwarden (unofficial Bitwarden&reg; server)</div>
      <div class="col text-center"></div>
      <div class="col text-right">
++      ({{ "webVault" | i18n }})
        {{ "versionNumber" | i18n : version }}
+     </div>
+   </div>
 diff --git a/apps/web/src/app/layouts/frontend-layout.component.html b/apps/web/src/app/layouts/frontend-layout.component.html
-index 84608acff0..9fdb254237 100644
+index 84608acff0..20f7a9666e 100644
 --- a/apps/web/src/app/layouts/frontend-layout.component.html
 +++ b/apps/web/src/app/layouts/frontend-layout.component.html
 @@ -1,6 +1,6 @@
@@ -191,12 +194,13 @@ index 84608acff0..9fdb254237 100644
      <bit-menu #environmentOptions>
        <a bitMenuItem href="https://vault.bitwarden.com" class="pr-4">
          <i
-@@ -29,6 +29,6 @@
+@@ -29,6 +29,7 @@
      <br />
    </div>
  
 -  &copy; {{ year }} Bitwarden Inc. <br />
 +  Vaultwarden (unofficial Bitwarden&reg; server)<br />
++  ({{ "webVault" | i18n }})
    {{ "versionNumber" | i18n : version }}
  </div>
 diff --git a/apps/web/src/app/layouts/navbar.component.html b/apps/web/src/app/layouts/navbar.component.html


### PR DESCRIPTION
Currently the web vault just displays the version number in the footer which seems to be confusing for many vaultwarden users as our server version number differs greatly from [Bitwardens versioning](https://bitwarden.com/help/versioning/).

So I was thinking that this might become a bit clearer if the footer says something like:

> Version 2023.5.1 (Web vault)

What do you think? I mean it would maybe be nicer if Bitwarden itself would display both web-vault version as well as the server version (by e.g. getting the version from `/api/config`) but that would probably be too big a change for our patch file.