### PR TITLE
Use node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 #    docker cp $image_id:/bw_web_vault.tar.gz .
 #    docker rm $image_id
 
-FROM node:16-bookworm as build
+FROM node:18-bookworm as build
 RUN node --version && npm --version
 
 # Prepare the folder to enable non-root, otherwise npm will refuse to run the postinstall


### PR DESCRIPTION
As discussed in #136 node 16 is EOL so it does not receive any security updates anymore. This PR updates the node version to the same version that Bitwarden is going to use which is currently node 18 (until they update their [`.nvmrc`](https://github.com/bitwarden/clients/blob/master/.nvmrc)).