### PR TITLE
update web-vault to v2024.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ USER node
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/bitwarden/clients/releases/tag/web-v2024.1.0
-ARG VAULT_VERSION=e8a54a70a5d136d4e0d7ccdb15d5056d681c3f47
+# Using https://github.com/bitwarden/clients/releases/tag/web-v2024.1.1
+ARG VAULT_VERSION=3c1ccc9cd9e669f8640001c524e20fb2f575e535
 
 WORKDIR /vault
 RUN git -c init.defaultBranch=main init && \


### PR DESCRIPTION
New web-vault release: [web-v2024.1.1](https://github.com/bitwarden/clients/releases/tag/web-v2024.1.1)

It contains two bug fixes (cf. [web-v2024.1.0...web-v2024.1.1](https://github.com/bitwarden/clients/compare/web-v2024.1.0...web-v2024.1.1)) that don't conflict with any of our changes so our patch file does not have to be updated.

As far as I've checked one change is irrelevant to us but the the refactoring might be relevant (but I've not tested the behavioral changes between the two versions).