### PR TITLE
Fix applying latest patch if patches is a symlink

### DIFF
--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -16,7 +16,7 @@ if [[ -z ${PATCH_NAME} ]]; then
     else
         echo "No exact patch file not found, using latest"
         # If not, use the latest one
-        PATCH_NAME="$(find ../patches -type f -print0 | xargs -0 basename -a | sort -V | tail -n1)"
+        PATCH_NAME="$(find ../patches/ -type f -print0 | xargs -0 basename -a | sort -V | tail -n1)"
     fi
 fi
 


### PR DESCRIPTION
In nixpkgs we symlink the patches directory to combine the different sources together. (https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/security/vaultwarden/webvault.nix#L32)

The find returns nothing, if it enounters a symlink. This can be trivially fixed.

```
 ➜ find /tmp/nix-build-vaultwarden-webvault-2024.1.1-npm-deps.drv-0/patches -type f -print0 | xargs -0 basename -a | sort -V | tail -n1
basename: missing operand
Try 'basename --help' for more information.
```