### PR TITLE
Strip query params when resolving subpath

### DIFF
--- a/patches/v2024.5.0.patch
+++ b/patches/v2024.5.0.patch
@@ -554,13 +554,13 @@ index c2eb37eea5..2b5ac93392 100644
 +    //
 +    // - `https://vaultwarden.example.com/base/path/`
 +    // - `https://vaultwarden.example.com/base/path/#/some/route[?queryParam=...]`
++    // - `https://vaultwarden.example.com/base/path/?queryParam=...`
 +    //
 +    // We want to get to just `https://vaultwarden.example.com/base/path`.
 +    let baseUrl = this.win.location.href;
-+    baseUrl = baseUrl.replace(/#.*/, ""); // Strip off `#` and everything after.
-+    baseUrl = baseUrl.replace(/\/+$/, ""); // Trim any trailing `/` chars.
++    baseUrl = baseUrl.replace(/(\/+|\/*#.*|\/*\?.*)$/, ""); // Strip off trailing `/`, `#`, `?` and everything after.
 +    const urls = { base: baseUrl };
- 
+
      // Find the region
      const domain = Utils.getDomain(this.win.location.href);
 diff --git a/apps/web/src/app/shared/loose-components.module.ts b/apps/web/src/app/shared/loose-components.module.ts


### PR DESCRIPTION
Hey

Had some issue with `subpath` handling with SSO.
Part of it was during redirection the url included query parameters and no hash mark.

I believe it makes sense to include it to make the base url resolution more robust.