### PR TITLE
Add separate build script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 builds
 docker_builds
 container_builds
+vault
 web-vault
 
 # Documentation

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 builds/
 docker_builds/
 container_builds/
+vault/
 web-vault/
 
 # Other

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ -z "$VAULT_VERSION" ]] ; then
+	echo "Missing VAULT_VERSION cannot build"
+	exit 1
+fi
+
+mkdir vault;
+cd vault;
+git -c init.defaultBranch=main init
+git remote add origin https://github.com/bitwarden/clients.git
+git fetch --depth 1 origin "${VAULT_VERSION}"
+git -c advice.detachedHead=false checkout FETCH_HEAD
+
+../scripts/apply_patches.sh
+npm ci
+cd -
+
+cd vault/apps/web
+npm run dist:oss:selfhost
+find build -name "*.map" -delete
+cd -
+
+mv vault/apps/web/build web-vault


### PR DESCRIPTION
Hey

A change to move part of the build process out of the docker file in an external script.

As for why:
 - It can help with testing by allowing to run locally, but this is limited by the rather strict node version checking of `npm ci`. 
 - It's mainly for the Playwright [PR](https://github.com/dani-garcia/vaultwarden/pull/4369) in Vaultwarden to be able to [build](https://github.com/Timshel/vaultwarden/blob/feature/playwright/playwright/compose/vaultwarden/build.sh#L18) aany commit without having to work with the `bw_web_builds/Dockerfile`.
 
 Additionally, removed the `chown node` logic since I had no issues when running the build.