### PR TITLE
Use checkout and build scripts in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,48 +18,28 @@
 FROM node:18-bookworm as build
 RUN node --version && npm --version
 
-# Prepare the folder to enable non-root, otherwise npm will refuse to run the postinstall
-RUN mkdir /vault
-RUN chown node:node /vault
-USER node
-
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
 # Using https://github.com/bitwarden/clients/releases/tag/web-v2024.5.1
 ARG VAULT_VERSION=9823f69c9d17e2d94de1cc005e01202dd95f0647
+ENV VAULT_VERSION=$VAULT_VERSION
+ENV VAULT_FOLDER=bw_clients
+ENV CHECKOUT_TAGS=false
 
-WORKDIR /vault
-RUN git -c init.defaultBranch=main init && \
-    git remote add origin https://github.com/bitwarden/clients.git && \
-    git fetch --depth 1 origin "${VAULT_VERSION}" && \
-    git -c advice.detachedHead=false checkout FETCH_HEAD
+RUN mkdir /bw_web_builds
+WORKDIR /bw_web_builds
 
-COPY --chown=node:node patches /patches
-COPY --chown=node:node resources /resources
-COPY --chown=node:node scripts/apply_patches.sh /apply_patches.sh
+COPY patches ./patches
+COPY resources ./resources
+COPY scripts ./scripts
 
-RUN bash /apply_patches.sh
+RUN ./scripts/checkout_web_vault.sh
+RUN ./scripts/patch_web_vault.sh
+RUN ./scripts/build_web_vault.sh
+RUN mv "${VAULT_FOLDER}/apps/web/build" ./web-vault
 
-# Build
-RUN npm ci
-
-# Switch to the web apps folder
-WORKDIR /vault/apps/web
-
-RUN npm run dist:oss:selfhost
-
-RUN printf '{"version":"%s"}' \
-      $(git -c 'versionsort.suffix=-' ls-remote --tags --refs --sort='v:refname' https://github.com/dani-garcia/bw_web_builds.git 'v*' | tail -n1 | grep -Eo '[^\/v]*$') \
-      > build/vw-version.json
-
-# Delete debugging map files, optional
-# RUN find build -name "*.map" -delete
-
-# Prepare the final archives
-RUN mv build web-vault
 RUN tar -czvf "bw_web_vault.tar.gz" web-vault --owner=0 --group=0
-
 # Output the sha256sum here so people are able to match the sha256sum from the CI with the assets and the downloaded version if needed
 RUN echo "sha256sum: $(sha256sum "bw_web_vault.tar.gz")"
 
@@ -67,7 +47,8 @@ RUN echo "sha256sum: $(sha256sum "bw_web_vault.tar.gz")"
 # The result is included both uncompressed and as a tar.gz, to be able to use it in the docker images and the github releases directly
 FROM scratch
 # hadolint ignore=DL3010
-COPY --from=build /vault/apps/web/bw_web_vault.tar.gz /bw_web_vault.tar.gz
-COPY --from=build /vault/apps/web/web-vault /web-vault
+COPY --from=build /bw_web_builds/bw_web_vault.tar.gz /bw_web_vault.tar.gz
+COPY --from=build /bw_web_builds/web-vault /web-vault
+
 # Added so docker create works, can't actually run a scratch image
 CMD [""]

--- a/scripts/.script_env
+++ b/scripts/.script_env
@@ -2,7 +2,8 @@
 # shellcheck disable=SC2034
 set -o pipefail -o errexit
 
-VAULT_FOLDER=web-vault
+VAULT_FOLDER=${VAULT_FOLDER:=web-vault}
+CHECKOUT_TAGS=${CHECKOUT_TAGS:=true}
 OUTPUT_FOLDER=builds
 
 function get_web_vault_version {

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -26,6 +26,7 @@ if [[ "${VAULT_VERSION}" =~ ^20[0-9]{2}\.[0-9]{1,2}.[0-9]{1} ]]; then
 elif [[ "${VAULT_VERSION}" =~ ^v20[0-9]{2}\.[0-9]{1,2}.[0-9]{1} ]]; then
     VAULT_VERSION="web-${VAULT_VERSION}"
 fi
+
 echo "Using: '${VAULT_VERSION}' to checkout bitwarden/client."
 
 if [ ! -d "${VAULT_FOLDER}" ]; then
@@ -47,10 +48,14 @@ else
     popd
 fi
 
+if [[ "$CHECKOUT_TAGS" == "true" ]]; then
+    CHECKOUT_ARGS="${CHECKOUT_ARGS:-} --tags"
+fi
+
 # Checkout the request
 pushd "${VAULT_FOLDER}"
     # Update branch and tag metadata
-    git fetch --tags --depth 1 origin "${VAULT_VERSION}"
+    git fetch --depth 1 ${CHECKOUT_ARGS:-} origin "${VAULT_VERSION}"
     # Checkout the branch we want
     git -c advice.detachedHead=false checkout FETCH_HEAD
 popd


### PR DESCRIPTION
Hey

Earlier opened a useless (sorry) PR since I had not RTFM :smile: and the docker build is not using all the available scripts.
Since I had already made the modification switching to using `checkout_web_vault` and `build_web_vault` was trivial.

Additionally, removed the `chown node` logic since I had no issues when running the build.