### PR TITLE
Strip query params when resolving subpath

### DIFF
--- a/patches/v2024.6.2.patch
+++ b/patches/v2024.6.2.patch
@@ -577,11 +577,11 @@ index c2eb37eea5..2b5ac93392 100644
 +    //
 +    // - `https://vaultwarden.example.com/base/path/`
 +    // - `https://vaultwarden.example.com/base/path/#/some/route[?queryParam=...]`
++    // - `https://vaultwarden.example.com/base/path/?queryParam=...`
 +    //
 +    // We want to get to just `https://vaultwarden.example.com/base/path`.
 +    let baseUrl = this.win.location.href;
-+    baseUrl = baseUrl.replace(/#.*/, ""); // Strip off `#` and everything after.
-+    baseUrl = baseUrl.replace(/\/+$/, ""); // Trim any trailing `/` chars.
++    baseUrl = baseUrl.replace(/(\/+|\/*#.*|\/*\?.*)$/, ""); // Strip off trailing `/`, `#`, `?` and everything after.
 +    const urls = { base: baseUrl };
  
      // Find the region


### PR DESCRIPTION
Same as https://github.com/dani-garcia/bw_web_builds/pull/170 but applied on latest patch [v2024.6.2.patch](https://github.com/dani-garcia/bw_web_builds/blob/master/patches/v2024.6.2.patch).

Edit: It appears that https://github.com/dani-garcia/bw_web_builds/pull/171 is not included too in the latest release; not sure if it's on purpose.