### PR TITLE
Add build env's

### DIFF
--- a/.build_env.template
+++ b/.build_env.template
@@ -1,0 +1,14 @@
+# shellcheck disable=SC2034,SC2148
+# ###
+# Do not use quotes for these variables!
+#
+# These variables will be loaded during the building process
+# This can be useful if you need to provide special variables for NodeJS or other applications
+# Make sure you export variables which are used for external scripts, else they will not be seen!
+# ###
+
+# Configure NodeJS Virtual Memory Allocation
+# NODE_OPTIONS=--max-old-space-size=4096
+# export NODE_OPTIONS
+
+# vim: syntax=sh filetype=sh

--- a/.env.template
+++ b/.env.template
@@ -12,4 +12,4 @@
 # GPG_SIGNING_USER=user@domain.tld
 # GPG_SIGNING_USER=MY_LONG_UNIQUE_GPG_KEY_IDENTIFIER
 
-# vim: syntax=ini
+# vim: syntax=sh filetype=sh

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ web-vault/
 
 # Other
 .env
+.build_env
 .vscode
 
 # Release files

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ WORKDIR /bw_web_builds
 COPY patches ./patches
 COPY resources ./resources
 COPY scripts ./scripts
+# Use a glob pattern here so builds will continue even if the `.build_env` does not exists
+COPY .build_env* ./
 
 RUN ./scripts/checkout_web_vault.sh
 RUN ./scripts/patch_web_vault.sh

--- a/scripts/.script_env
+++ b/scripts/.script_env
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
 set -o pipefail -o errexit
+ENV_BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
 VAULT_FOLDER=${VAULT_FOLDER:=web-vault}
 CHECKOUT_TAGS=${CHECKOUT_TAGS:=true}
@@ -17,3 +18,11 @@ function get_web_vault_version {
     # The extracted tag could start with either `web-`, `desktop-`, `cli-` or `browser-`
     echo "${VAULT_VERSION#*-}"
 }
+
+# Load build environment variables if it exists
+if [ -f "${ENV_BASEDIR}/../.build_env" ]; then
+  # shellcheck source=../.build_env
+  . "${ENV_BASEDIR}/../.build_env"
+fi
+
+unset ENV_BASEDIR

--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -2,15 +2,15 @@
 set -o pipefail -o errexit
 
 function replace_embedded_svg_icon() {
-if [ ! -f $1 ]; then echo "$1 does not exist"; exit -1; fi
-if [ ! -f $2 ]; then echo "$2 does not exist"; exit -1; fi
+if [ ! -f "$1" ]; then echo "$1 does not exist"; exit 255; fi
+if [ ! -f "$2" ]; then echo "$2 does not exist"; exit 255; fi
 
 echo "'$1' -> '$2'"
 
 first='`$'
 last='^`'
 sed -i "/$first/,/$last/{ /$first/{p; r $1
-}; /$last/p; d }" $2
+}; /$last/p; d }" "$2"
 }
 
 # If a patch was not provided, try to choose one
@@ -28,7 +28,7 @@ if [[ -z ${PATCH_NAME} ]]; then
     else
         echo "No exact patch file not found, using latest"
         # If not, use the latest one
-        PATCH_NAME="$(find ../patches/ -type f -print0 | xargs -0 basename -a | sort -V | tail -n1)"
+        PATCH_NAME="$(find ../patches/ -type f -name '*.patch' -print0 | xargs -0 basename -a | sort -V | tail -n1)"
     fi
 fi
 

--- a/scripts/package_web_vault.sh
+++ b/scripts/package_web_vault.sh
@@ -2,6 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
+# Error handling
 handle_error() {
     read -n1 -r -p "FAILED: line $1, exit code $2. Press any key to exit..." _
     exit 1


### PR DESCRIPTION
Sometimes you want to set specific environment variables during build. For example, on some systems nodejs needs some extra options to be able to run correctly on low memory systems. To make sure this will be loaded and works on both scripts and Dockerfile, you can now create a `.build_env` file. This `.build_env` file should contain all the variables (including an export command) you want to expose during build time.

The template file has a nodejs example.

Closes #183

Also fixed some shellcheck warnings.