### PR TITLE
update web-vault to v2025.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/bitwarden/clients/releases/tag/web-v2025.1.2
-ARG VAULT_VERSION=9b62ed5b7a6ef4d26f7241be551ae4dd480648a6
+# Using https://github.com/bitwarden/clients/releases/tag/web-v2025.2.0
+ARG VAULT_VERSION=d29a061e29d59ff9a21ac269e62318b114e12701
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/bitwarden/clients/releases/tag/web-v2025.2.0
-ARG VAULT_VERSION=d29a061e29d59ff9a21ac269e62318b114e12701
+# Using https://github.com/bitwarden/clients/releases/tag/web-v2025.2.1
+ARG VAULT_VERSION=74b25cbe8aa9051a17679c603c3c92953eb75aed
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/bitwarden/clients/releases/tag/web-v2025.2.1
-ARG VAULT_VERSION=74b25cbe8aa9051a17679c603c3c92953eb75aed
+# Using https://github.com/bitwarden/clients/releases/tag/web-v2025.2.2
+ARG VAULT_VERSION=172cbd2e77e235e0eead6bb5022ad9185a45cafd
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/bitwarden/clients/releases/tag/web-v2025.1.1
-ARG VAULT_VERSION=06b60c6853dc6c510eaf5ee68d547d02baee8934
+# Using https://github.com/bitwarden/clients/releases/tag/web-v2025.1.2
+ARG VAULT_VERSION=9b62ed5b7a6ef4d26f7241be551ae4dd480648a6
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/bitwarden/clients/releases/tag/web-v2025.2.2
-ARG VAULT_VERSION=172cbd2e77e235e0eead6bb5022ad9185a45cafd
+# Using https://github.com/bitwarden/clients/releases/tag/web-v2025.3.1
+ARG VAULT_VERSION=f941cb5c29ba0af2902cd0226540378bdeba568c
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/patches/v2025.1.2.patch
+++ b/patches/v2025.1.2.patch
@@ -1,0 +1,798 @@
+diff --git a/apps/web/config/base.json b/apps/web/config/base.json
+index e64ef6ebeb..b41ca4219d 100644
+--- a/apps/web/config/base.json
++++ b/apps/web/config/base.json
+@@ -1,11 +1,5 @@
+ {
+   "urls": {},
+-  "stripeKey": "pk_test_KPoCfZXu7mznb9uSCPZ2JpTD",
+-  "braintreeKey": "sandbox_r72q8jq6_9pnxkwm75f87sdc2",
+-  "paypal": {
+-    "businessId": "AD3LAUZSNVPJY",
+-    "buttonAction": "https://www.sandbox.paypal.com/cgi-bin/webscr"
+-  },
+   "dev": {
+     "port": 8080,
+     "allowedHosts": "auto"
+diff --git a/apps/web/package.json b/apps/web/package.json
+index 7047b0fb13..b3b629248b 100644
+--- a/apps/web/package.json
++++ b/apps/web/package.json
+@@ -3,11 +3,8 @@
+   "version": "2025.1.2",
+   "scripts": {
+     "build:oss": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" webpack",
+-    "build:bit": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" webpack -c ../../bitwarden_license/bit-web/webpack.config.js",
+     "build:oss:watch": "webpack serve",
+-    "build:bit:watch": "webpack serve -c ../../bitwarden_license/bit-web/webpack.config.js",
+     "build:bit:dev": "cross-env ENV=development npm run build:bit",
+-    "build:bit:dev:analyze": "cross-env LOGGING=false webpack -c ../../bitwarden_license/bit-web/webpack.config.js --profile --json > stats.json && npx webpack-bundle-analyzer stats.json build/",
+     "build:bit:dev:watch": "cross-env ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" npm run build:bit:watch",
+     "build:bit:qa": "cross-env NODE_ENV=production ENV=qa npm run build:bit",
+     "build:bit:euprd": "cross-env NODE_ENV=production ENV=euprd npm run build:bit",
+diff --git a/apps/web/src/app/admin-console/organizations/create/organization-information.component.html b/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
+index e0a8006081..789efd9264 100644
+--- a/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
++++ b/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
+@@ -12,7 +12,7 @@
+       <input bitInput type="text" formControlName="name" />
+     </bit-form-field>
+     <bit-form-field class="tw-w-1/2">
+-      <bit-label>{{ "billingEmail" | i18n }}</bit-label>
++      <bit-label>{{ "email" | i18n }}</bit-label>
+       <input bitInput type="email" formControlName="billingEmail" />
+     </bit-form-field>
+     <bit-form-field class="tw-w-1/2" *ngIf="isProvider">
+diff --git a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
+index f65da9b87a..e6db3b4480 100644
+--- a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
++++ b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
+@@ -140,6 +140,7 @@ export class OrganizationLayoutComponent implements OnInit {
+   }
+ 
+   canShowBillingTab(organization: Organization): boolean {
++    return false; // disable billing tab in Vaultwarden
+     return canAccessBillingTab(organization);
+   }
+ 
+diff --git a/apps/web/src/app/admin-console/organizations/members/members.component.ts b/apps/web/src/app/admin-console/organizations/members/members.component.ts
+index 1ea7764222..bc76f369c0 100644
+--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
++++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
+@@ -209,11 +209,7 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
+             .find((p) => p.organizationId === this.organization.id);
+           this.orgResetPasswordPolicyEnabled = resetPasswordPolicy?.enabled;
+ 
+-          const billingMetadata = await this.billingApiService.getOrganizationBillingMetadata(
+-            this.organization.id,
+-          );
+-
+-          this.orgIsOnSecretsManagerStandalone = billingMetadata.isOnSecretsManagerStandalone;
++          this.orgIsOnSecretsManagerStandalone = false; // don't get billing metadata
+ 
+           await this.load();
+ 
+diff --git a/apps/web/src/app/admin-console/organizations/settings/account.component.html b/apps/web/src/app/admin-console/organizations/settings/account.component.html
+index b3fac56c0b..796a1a817a 100644
+--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
++++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
+@@ -16,7 +16,7 @@
+           <input bitInput id="orgName" type="text" formControlName="orgName" />
+         </bit-form-field>
+         <bit-form-field>
+-          <bit-label>{{ "billingEmail" | i18n }}</bit-label>
++          <bit-label>{{ "email" | i18n }}</bit-label>
+           <input bitInput id="billingEmail" formControlName="billingEmail" type="email" />
+         </bit-form-field>
+       </div>
+diff --git a/apps/web/src/app/admin-console/organizations/settings/account.component.ts b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+index f2834b6109..a48d24a982 100644
+--- a/apps/web/src/app/admin-console/organizations/settings/account.component.ts
++++ b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+@@ -97,7 +97,7 @@ export class AccountComponent implements OnInit, OnDestroy {
+   ) {}
+ 
+   async ngOnInit() {
+-    this.selfHosted = this.platformUtilsService.isSelfHost();
++    this.selfHosted = false; // set to false so we can rename organizations
+ 
+     const userId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
+     this.route.params
+@@ -195,6 +195,7 @@ export class AccountComponent implements OnInit, OnDestroy {
+   };
+ 
+   submitCollectionManagement = async () => {
++    return; // flexible collections are not supported by Vaultwarden
+     const request = new OrganizationCollectionManagementUpdateRequest();
+     request.limitCollectionCreation =
+       this.collectionManagementFormGroup.value.limitCollectionCreation;
+diff --git a/apps/web/src/app/app.component.html b/apps/web/src/app/app.component.html
+index a39c045e0e..9d72e609b4 100644
+--- a/apps/web/src/app/app.component.html
++++ b/apps/web/src/app/app.component.html
+@@ -3,7 +3,7 @@
+    when the body has the layout_frontend class. Having this match the index allows for a duplicative yet seamless
+    loading state here for process reloading. -->
+   <div class="tw-p-8 tw-flex">
+-    <img class="new-logo-themed" alt="Bitwarden" />
++    <img class="new-logo-themed" alt="Vaultwarden" />
+     <div class="spinner-container tw-justify-center">
+       <i
+         class="bwi bwi-spinner bwi-spin bwi-3x tw-text-muted"
+diff --git a/apps/web/src/app/app.component.ts b/apps/web/src/app/app.component.ts
+index 825b610bab..28f6fa510e 100644
+--- a/apps/web/src/app/app.component.ts
++++ b/apps/web/src/app/app.component.ts
+@@ -211,6 +211,10 @@ export class AppComponent implements OnDestroy, OnInit {
+             break;
+           }
+           case "showToast":
++            if (typeof message.text === "string" && typeof crypto.subtle === "undefined") {
++              message.title = "This browser requires HTTPS to use the web vault";
++              message.text = "Check the Vaultwarden wiki for details on how to enable it";
++            }
+             this.toastService._showToast(message);
+             break;
+           case "convertAccountToKeyConnector":
+diff --git a/apps/web/src/app/auth/settings/change-password.component.html b/apps/web/src/app/auth/settings/change-password.component.html
+index 91144fdfc1..d3dc4410c9 100644
+--- a/apps/web/src/app/auth/settings/change-password.component.html
++++ b/apps/web/src/app/auth/settings/change-password.component.html
+@@ -125,5 +125,3 @@
+     {{ "changeMasterPassword" | i18n }}
+   </button>
+ </form>
+-
+-<app-webauthn-login-settings></app-webauthn-login-settings>
+diff --git a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
+index de187d2c33..c33f49fd70 100644
+--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
++++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
+@@ -189,11 +189,11 @@ export class TwoFactorSetupAuthenticatorComponent
+     new window.QRious({
+       element: document.getElementById("qr"),
+       value:
+-        "otpauth://totp/Bitwarden:" +
++        "otpauth://totp/Vaultwarden:" +
+         Utils.encodeRFC3986URIComponent(email) +
+         "?secret=" +
+         encodeURIComponent(this.key) +
+-        "&issuer=Bitwarden",
++        "&issuer=Vaultwarden",
+       size: 160,
+     });
+   }
+diff --git a/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts b/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
+index d533badabf..6512ecbd13 100644
+--- a/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
++++ b/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
+@@ -54,6 +54,7 @@ export class OrgBillingHistoryViewComponent implements OnInit, OnDestroy {
+ 
+     this.loading = true;
+ 
++    /* disable billing history
+     const openInvoicesPromise = this.organizationBillingApiService.getBillingInvoices(
+       this.organizationId,
+       "open",
+@@ -87,6 +88,7 @@ export class OrgBillingHistoryViewComponent implements OnInit, OnDestroy {
+       openInvoices.length <= pageSize ||
+       paidInvoices.length <= pageSize ||
+       transactions.length <= pageSize;
++    */
+ 
+     this.loading = false;
+   }
+diff --git a/apps/web/src/app/billing/organizations/organization-plans.component.html b/apps/web/src/app/billing/organizations/organization-plans.component.html
+index 2566250c82..0aafdc5ba9 100644
+--- a/apps/web/src/app/billing/organizations/organization-plans.component.html
++++ b/apps/web/src/app/billing/organizations/organization-plans.component.html
+@@ -6,7 +6,7 @@
+   ></i>
+   <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+ </ng-container>
+-<ng-container *ngIf="createOrganization && selfHosted">
++<ng-container *ngIf="createOrganization && false">
+   <ng-container *ngIf="!(useLicenseUploaderComponent$ | async)">
+     <p bitTypography="body1">{{ "uploadLicenseFileOrg" | i18n }}</p>
+     <form [formGroup]="selfHostedForm" [bitSubmit]="submit">
+@@ -40,12 +40,7 @@
+     (onLicenseFileUploaded)="onLicenseFileUploaded($event)"
+   />
+ </ng-container>
+-<form
+-  [formGroup]="formGroup"
+-  [bitSubmit]="submit"
+-  *ngIf="!loading && !selfHosted && this.passwordManagerPlans && this.secretsManagerPlans"
+-  class="tw-pt-6"
+->
++<form [formGroup]="formGroup" [bitSubmit]="submit" *ngIf="!loading" class="tw-pt-6">
+   <bit-section [ngClass]="{ 'tw-hidden': !createOrganization }">
+     <app-org-info
+       (changedBusinessOwned)="changedOwnedBusiness()"
+diff --git a/apps/web/src/app/billing/organizations/organization-plans.component.ts b/apps/web/src/app/billing/organizations/organization-plans.component.ts
+index f1e090ef50..875f6d7845 100644
+--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
++++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
+@@ -194,13 +194,12 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+           .organizations$(userId)
+           .pipe(getOrganizationById(this.organizationId)),
+       );
+-      this.billing = await this.organizationApiService.getBilling(this.organizationId);
+-      this.sub = await this.organizationApiService.getSubscription(this.organizationId);
+-      this.taxInformation = await this.organizationApiService.getTaxInfo(this.organizationId);
+-    } else if (!this.selfHosted) {
+-      this.taxInformation = await this.apiService.getTaxInfo();
++      this.billing = null; // no billing in Vaultwarden
++      this.sub = null; // no subscriptions in Vaultwarden;
++      this.taxInformation = null; // no taxes in Vaultwarden;
+     }
+ 
++    /* no need to ask /api/plans because Vaultwarden only supports the free plan
+     if (!this.selfHosted) {
+       const plans = await this.apiService.getPlans();
+       this.passwordManagerPlans = plans.data.filter((plan) => !!plan.PasswordManager);
+@@ -236,6 +235,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+       this.plan = providerDefaultPlan.type;
+       this.productTier = providerDefaultPlan.productTier;
+     }
++    end of asking /api/plans in Vaultwarden */
+ 
+     if (!this.createOrganization) {
+       this.upgradeFlowPrefillForm();
+@@ -285,6 +285,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get upgradeRequiresPaymentMethod() {
++    return false; // Vaultwarden is always free
+     return (
+       this.organization?.productTierType === ProductTierType.Free &&
+       !this.showFree &&
+@@ -320,6 +321,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get selectableProducts() {
++    return null; // there are no products to select in Vaultwarden
+     if (this.acceptingSponsorship) {
+       const familyPlan = this.passwordManagerPlans.find(
+         (plan) => plan.type === PlanType.FamiliesAnnually,
+@@ -351,6 +353,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get selectablePlans() {
++    return null; // no plans to select in Vaultwarden
+     const selectedProductTierType = this.formGroup.controls.productTier.value;
+     const result =
+       this.passwordManagerPlans?.filter(
+@@ -481,6 +484,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get planOffersSecretsManager() {
++    return false; // no support for secrets manager in Vaultwarden
+     return this.selectedSecretsManagerPlan != null;
+   }
+ 
+@@ -489,6 +493,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   changedProduct() {
++    return; // no choice of products in Vaultwarden
+     const selectedPlan = this.selectablePlans[0];
+ 
+     this.setPlanType(selectedPlan.type);
+@@ -617,9 +622,8 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+         const collectionCt = collection.encryptedString;
+         const orgKeys = await this.keyService.makeKeyPair(orgKey[1]);
+ 
+-        orgId = this.selfHosted
+-          ? await this.createSelfHosted(key, collectionCt, orgKeys)
+-          : await this.createCloudHosted(key, collectionCt, orgKeys, orgKey[1]);
++        // always use createCloudHosted() to disable license file upload
++        orgId = await this.createCloudHosted(key, collectionCt, orgKeys, orgKey[1]);
+ 
+         this.toastService.showToast({
+           variant: "success",
+@@ -767,7 +771,9 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+     request.billingEmail = this.formGroup.controls.billingEmail.value;
+     request.initiationPath = "New organization creation in-product";
+     request.keys = new OrganizationKeysRequest(orgKeys[0], orgKeys[1].encryptedString);
++    request.planType = PlanType.Free; // always select the free plan in Vaultwarden
+ 
++    /* there is no plan to select in Vaultwarden
+     if (this.selectedPlan.type === PlanType.Free) {
+       request.planType = PlanType.Free;
+     } else {
+@@ -792,6 +798,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+ 
+     // Secrets Manager
+     this.buildSecretsManagerRequest(request);
++    end plan selection and no support for secret manager in Vaultwarden */
+ 
+     if (this.hasProvider) {
+       const providerRequest = new ProviderOrganizationCreateRequest(
+@@ -853,6 +860,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   private buildSecretsManagerRequest(
+     request: OrganizationCreateRequest | OrganizationUpgradeRequest,
+   ): void {
++    return; // Vaultwarden does not support SecretsManager
+     const formValues = this.secretsManagerForm.value;
+ 
+     request.useSecretsManager = this.planOffersSecretsManager && formValues.enabled;
+@@ -871,6 +879,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   private upgradeFlowPrefillForm() {
++    return; // Vaultwarden only supports free plan
+     if (this.acceptingSponsorship) {
+       this.formGroup.controls.productTier.setValue(ProductTierType.Families);
+       this.changedProduct();
+diff --git a/apps/web/src/app/core/router.service.ts b/apps/web/src/app/core/router.service.ts
+index ff0aea47b9..21ec31a19a 100644
+--- a/apps/web/src/app/core/router.service.ts
++++ b/apps/web/src/app/core/router.service.ts
+@@ -61,7 +61,7 @@ export class RouterService {
+       .subscribe((event: NavigationEnd) => {
+         this.currentUrl = event.url;
+ 
+-        let title = i18nService.t("bitWebVault");
++        let title = "Vaultwarden Web";
+ 
+         if (this.currentUrl.includes("/sm/")) {
+           title = i18nService.t("bitSecretsManager");
+diff --git a/apps/web/src/app/core/web-platform-utils.service.ts b/apps/web/src/app/core/web-platform-utils.service.ts
+index 3df2a7d895..f73d811690 100644
+--- a/apps/web/src/app/core/web-platform-utils.service.ts
++++ b/apps/web/src/app/core/web-platform-utils.service.ts
+@@ -135,14 +135,17 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
+   }
+ 
+   isDev(): boolean {
++    return false; // treat Vaultwarden as production ready
+     return process.env.NODE_ENV === "development";
+   }
+ 
+   isSelfHost(): boolean {
++    return true; // treat Vaultwarden as self hosted
+     return WebPlatformUtilsService.isSelfHost();
+   }
+ 
+   static isSelfHost(): boolean {
++    return true; // treat Vaultwarden as self hosted
+     return process.env.ENV.toString() === "selfhosted";
+   }
+ 
+diff --git a/apps/web/src/app/layouts/frontend-layout.component.html b/apps/web/src/app/layouts/frontend-layout.component.html
+index d19af54f5d..03c8edf631 100644
+--- a/apps/web/src/app/layouts/frontend-layout.component.html
++++ b/apps/web/src/app/layouts/frontend-layout.component.html
+@@ -3,6 +3,12 @@
+ <footer class="tw-text-center tw-my-12">
+   <environment-selector></environment-selector>
+ 
+-  <div bitTypography="body2">&copy; {{ year }} Bitwarden Inc.</div>
++  <div bitTypography="body2">Vaultwarden Web</div>
+   <div bitTypography="body2">{{ version }}</div>
++  <br />
++  <div bitTypography="helper" id="vw-disclaimer">
++    A modified version of the Bitwarden&reg; Web Vault for Vaultwarden (an unofficial rewrite of the
++    Bitwarden&reg; server).<br />
++    Vaultwarden is not associated with the Bitwarden&reg; project nor Bitwarden Inc.
++  </div>
+ </footer>
+diff --git a/apps/web/src/app/layouts/header/web-header.component.html b/apps/web/src/app/layouts/header/web-header.component.html
+index 7cba19b29a..024b14daad 100644
+--- a/apps/web/src/app/layouts/header/web-header.component.html
++++ b/apps/web/src/app/layouts/header/web-header.component.html
+@@ -61,7 +61,12 @@
+                 <i class="bwi bwi-fw bwi-user" aria-hidden="true"></i>
+                 {{ "accountSettings" | i18n }}
+               </a>
+-              <a bitMenuItem href="https://bitwarden.com/help/" target="_blank" rel="noreferrer">
++              <a
++                bitMenuItem
++                href="https://github.com/dani-garcia/vaultwarden"
++                target="_blank"
++                rel="noreferrer"
++              >
+                 <i class="bwi bwi-fw bwi-question-circle" aria-hidden="true"></i>
+                 {{ "getHelp" | i18n }}
+               </a>
+diff --git a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
+index 08195d95bf..f51a216a14 100644
+--- a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
++++ b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
+@@ -10,10 +10,7 @@
+   >
+   </bit-nav-item>
+   <ng-container *ngIf="moreProducts$ | async as moreProducts">
+-    <section
+-      *ngIf="moreProducts.length > 0"
+-      class="tw-mt-2 tw-flex tw-w-full tw-flex-col tw-gap-2 tw-border-0"
+-    >
++    <section *ngIf="false" class="tw-mt-2 tw-flex tw-w-full tw-flex-col tw-gap-2 tw-border-0">
+       <span class="tw-text-xs !tw-text-alt2 tw-p-2 tw-pb-0">{{ "moreFromBitwarden" | i18n }}</span>
+       <ng-container *ngFor="let more of moreProducts">
+         <!-- <a> for when the marketing route is external -->
+diff --git a/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html b/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
+index 204737eee2..9bee4f6e03 100644
+--- a/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
++++ b/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
+@@ -30,7 +30,7 @@
+ 
+     <!-- Other options -->
+     <section
+-      *ngIf="products.other.length > 0"
++      *ngIf="false"
+       class="tw-mt-4 tw-flex tw-w-full tw-flex-col tw-gap-2 tw-border-0 tw-border-t tw-border-solid tw-border-t-text-muted tw-p-2 tw-pb-0"
+     >
+       <span class="tw-mb-1 tw-text-xs tw-text-muted">{{ "moreFromBitwarden" | i18n }}</span>
+diff --git a/apps/web/src/app/layouts/user-layout.component.ts b/apps/web/src/app/layouts/user-layout.component.ts
+index f0ac3ef9b4..f6e7f5a492 100644
+--- a/apps/web/src/app/layouts/user-layout.component.ts
++++ b/apps/web/src/app/layouts/user-layout.component.ts
+@@ -3,7 +3,7 @@
+ import { CommonModule } from "@angular/common";
+ import { Component, OnInit } from "@angular/core";
+ import { RouterModule } from "@angular/router";
+-import { Observable, switchMap } from "rxjs";
++import { Observable, of } from "rxjs";
+ 
+ import { JslibModule } from "@bitwarden/angular/jslib.module";
+ import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+@@ -41,15 +41,14 @@ export class UserLayoutComponent implements OnInit {
+     private billingAccountProfileStateService: BillingAccountProfileStateService,
+     private accountService: AccountService,
+   ) {
+-    this.showSubscription$ = this.accountService.activeAccount$.pipe(
+-      switchMap((account) =>
+-        this.billingAccountProfileStateService.canViewSubscription$(account.id),
+-      ),
+-    );
++    this.showSubscription$ = of(false); // always hide subscriptions in Vaultwarden
+   }
+ 
+   async ngOnInit() {
+     document.body.classList.remove("layout_frontend");
+     await this.syncService.fullSync(false);
++
++    this.hasFamilySponsorshipAvailable$ = of(false); // disable family Sponsorships in Vaultwarden
++    this.showSponsoredFamilies$ = of(false); // disable family Sponsorships in Vaultwarden
+   }
+ }
+diff --git a/apps/web/src/app/platform/web-environment.service.ts b/apps/web/src/app/platform/web-environment.service.ts
+index 1df842d6b3..d61637c92e 100644
+--- a/apps/web/src/app/platform/web-environment.service.ts
++++ b/apps/web/src/app/platform/web-environment.service.ts
+@@ -38,7 +38,17 @@ export class WebEnvironmentService extends DefaultEnvironmentService {
+     super(stateProvider, accountService, additionalRegionConfigs);
+ 
+     // The web vault always uses the current location as the base url
+-    envUrls.base ??= this.win.location.origin;
++    // If the base URL is `https://vaultwarden.example.com/base/path/`,
++    // `window.location.href` should have one of the following forms:
++    //
++    // - `https://vaultwarden.example.com/base/path/`
++    // - `https://vaultwarden.example.com/base/path/#/some/route[?queryParam=...]`
++    // - `https://vaultwarden.example.com/base/path/?queryParam=...`
++    //
++    // We want to get to just `https://vaultwarden.example.com/base/path`.
++    let baseUrl = this.win.location.href;
++    baseUrl = baseUrl.replace(/(\/+|\/*#.*|\/*\?.*)$/, ""); // Strip off trailing `/`, `#`, `?` and everything after.
++    envUrls.base ??= baseUrl;
+ 
+     // Find the region
+     const currentHostname = new URL(this.win.location.href).hostname;
+diff --git a/apps/web/src/app/tools/send/add-edit.component.html b/apps/web/src/app/tools/send/add-edit.component.html
+index 7eade18a7c..b8f865faa7 100644
+--- a/apps/web/src/app/tools/send/add-edit.component.html
++++ b/apps/web/src/app/tools/send/add-edit.component.html
+@@ -230,7 +230,12 @@
+             <bit-label for="password" *ngIf="!hasPassword">{{ "password" | i18n }}</bit-label>
+             <bit-label for="password" *ngIf="hasPassword">{{ "newPassword" | i18n }}</bit-label>
+ 
+-            <input bitInput type="password" formControlName="password" />
++            <input
++              bitInput
++              type="password"
++              formControlName="password"
++              autocomplete="new-password"
++            />
+             <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
+             <bit-hint>{{ "sendPasswordDesc" | i18n }}</bit-hint>
+           </bit-form-field>
+diff --git a/apps/web/src/app/tools/send/send-access-explainer.component.html b/apps/web/src/app/tools/send/send-access-explainer.component.html
+index f56b68cc29..284b916514 100644
+--- a/apps/web/src/app/tools/send/send-access-explainer.component.html
++++ b/apps/web/src/app/tools/send/send-access-explainer.component.html
+@@ -1,18 +1,5 @@
+ <div class="tw-text-center tw-text-muted">
+   <p bitTypography="body2" class="tw-mb-0">
+     {{ "sendAccessTaglineProductDesc" | i18n }}
+-    {{ "sendAccessTaglineLearnMore" | i18n }}
+-    <a
+-      bitLink
+-      href="https://www.bitwarden.com/products/send?source=web-vault"
+-      target="_blank"
+-      rel="noreferrer"
+-      >Bitwarden Send</a
+-    >
+-    {{ "sendAccessTaglineOr" | i18n }}
+-    <a bitLink routerLink="/signup" target="_blank" rel="noreferrer">{{
+-      "sendAccessTaglineSignUp" | i18n
+-    }}</a>
+-    {{ "sendAccessTaglineTryToday" | i18n }}
+   </p>
+ </div>
+diff --git a/apps/web/src/index.html b/apps/web/src/index.html
+index 0b8ea86491..5d98411f46 100644
+--- a/apps/web/src/index.html
++++ b/apps/web/src/index.html
+@@ -5,19 +5,21 @@
+     <meta name="viewport" content="width=1010" />
+     <meta name="theme-color" content="#175DDC" />
+ 
+-    <title page-title>Bitwarden Web vault</title>
++    <title page-title>Vaultwarden Web</title>
+ 
+     <link rel="apple-touch-icon" sizes="180x180" href="images/icons/apple-touch-icon.png" />
+     <link rel="icon" type="image/png" sizes="32x32" href="images/icons/favicon-32x32.png" />
+     <link rel="icon" type="image/png" sizes="16x16" href="images/icons/favicon-16x16.png" />
+     <link rel="mask-icon" href="images/icons/safari-pinned-tab.svg" color="#175DDC" />
+     <link rel="manifest" href="manifest.json" />
++    <!-- webpackIgnore: true -->
++    <link rel="stylesheet" href="css/vaultwarden.css" />
+   </head>
+   <body class="layout_frontend">
+     <app-root>
+       <!-- Note: any changes to this html need to be made in the app.component.html as well -->
+       <div class="tw-p-8 tw-flex">
+-        <img class="new-logo-themed" alt="Bitwarden" />
++        <img class="new-logo-themed" alt="Vaultwarden" />
+         <div class="spinner-container tw-justify-center">
+           <i
+             class="bwi bwi-spinner bwi-spin bwi-3x tw-text-muted"
+diff --git a/apps/web/src/manifest.json b/apps/web/src/manifest.json
+index 92a1204c60..d9ff4771a3 100644
+--- a/apps/web/src/manifest.json
++++ b/apps/web/src/manifest.json
+@@ -1,5 +1,5 @@
+ {
+-  "name": "Bitwarden Vault",
++  "name": "Vaultwarden Web",
+   "icons": [
+     {
+       "src": "images/icons/android-chrome-192x192.png",
+@@ -12,6 +12,6 @@
+       "type": "image/png"
+     }
+   ],
+-  "theme_color": "#175DDC",
+-  "background_color": "#175DDC"
++  "theme_color": "#FFFFFF",
++  "background_color": "#FFFFFF"
+ }
+diff --git a/apps/web/src/scss/tailwind.css b/apps/web/src/scss/tailwind.css
+index 1ac7b15401..0c388f6787 100644
+--- a/apps/web/src/scss/tailwind.css
++++ b/apps/web/src/scss/tailwind.css
+@@ -52,7 +52,7 @@
+   img.new-logo-themed {
+     @apply tw-block;
+ 
+-    width: 128px;
++    width: 175px;
+   }
+   .theme_light img.new-logo-themed {
+     content: url("../images/logo.svg");
+diff --git a/apps/web/tailwind.config.js b/apps/web/tailwind.config.js
+index 2c0108ca3e..85d3689ea3 100644
+--- a/apps/web/tailwind.config.js
++++ b/apps/web/tailwind.config.js
+@@ -8,7 +8,6 @@ config.content = [
+   "../../libs/key-management/src/**/*.{html,ts}",
+   "../../libs/vault/src/**/*.{html,ts}",
+   "../../libs/angular/src/**/*.{html,ts}",
+-  "../../bitwarden_license/bit-web/src/**/*.{html,ts}",
+ ];
+ 
+ module.exports = config;
+diff --git a/apps/web/tsconfig.json b/apps/web/tsconfig.json
+index 701808df13..a4a5ce093a 100644
+--- a/apps/web/tsconfig.json
++++ b/apps/web/tsconfig.json
+@@ -10,7 +10,6 @@
+       "@bitwarden/auth/angular": ["../../libs/auth/src/angular"],
+       "@bitwarden/auth/common": ["../../libs/auth/src/common"],
+       "@bitwarden/billing": ["../../libs/billing/src"],
+-      "@bitwarden/bit-common/*": ["../../bitwarden_license/bit-common/src/*"],
+       "@bitwarden/common/*": ["../../libs/common/src/*"],
+       "@bitwarden/components": ["../../libs/components/src"],
+       "@bitwarden/generator-components": ["../../libs/tools/generator/components/src"],
+diff --git a/clients.code-workspace b/clients.code-workspace
+index f7d86d2a24..75389727d2 100644
+--- a/clients.code-workspace
++++ b/clients.code-workspace
+@@ -8,18 +8,10 @@
+       "name": "web vault",
+       "path": "apps/web",
+     },
+-    {
+-      "name": "web vault (bit)",
+-      "path": "bitwarden_license/bit-web",
+-    },
+     {
+       "name": "cli",
+       "path": "apps/cli",
+     },
+-    {
+-      "name": "cli (bit)",
+-      "path": "bitwarden_license/bit-cli",
+-    },
+     {
+       "name": "desktop",
+       "path": "apps/desktop",
+@@ -32,10 +24,6 @@
+       "name": "libs",
+       "path": "libs",
+     },
+-    {
+-      "name": "common (bit)",
+-      "path": "bitwarden_license/bit-common",
+-    },
+   ],
+   "settings": {
+     "eslint.options": {
+diff --git a/jest.config.js b/jest.config.js
+index 3ed082bcbc..3c385865d8 100644
+--- a/jest.config.js
++++ b/jest.config.js
+@@ -20,9 +20,6 @@ module.exports = {
+     "<rootDir>/apps/cli/jest.config.js",
+     "<rootDir>/apps/desktop/jest.config.js",
+     "<rootDir>/apps/web/jest.config.js",
+-    "<rootDir>/bitwarden_license/bit-web/jest.config.js",
+-    "<rootDir>/bitwarden_license/bit-cli/jest.config.js",
+-    "<rootDir>/bitwarden_license/bit-common/jest.config.js",
+ 
+     "<rootDir>/libs/admin-console/jest.config.js",
+     "<rootDir>/libs/angular/jest.config.js",
+diff --git a/libs/angular/src/auth/components/register.component.ts b/libs/angular/src/auth/components/register.component.ts
+index e4787aa8c0..1675a45a33 100644
+--- a/libs/angular/src/auth/components/register.component.ts
++++ b/libs/angular/src/auth/components/register.component.ts
+@@ -108,6 +108,14 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
+   }
+ 
+   async submit(showToast = true) {
++    if (typeof crypto.subtle === "undefined") {
++      this.platformUtilsService.showToast(
++        "error",
++        "This browser requires HTTPS to use the web vault",
++        "Check the Vaultwarden wiki for details on how to enable it",
++      );
++      return;
++    }
+     let email = this.formGroup.value.email;
+     email = email.trim().toLowerCase();
+     let name = this.formGroup.value.name;
+diff --git a/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts b/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
+index 04dc3b6dfd..2791b0bc17 100644
+--- a/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
++++ b/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
+@@ -8,6 +8,8 @@ import { AnonLayoutComponent } from "@bitwarden/auth/angular";
+ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+ import { Icon, Translation } from "@bitwarden/components";
+ 
++import { BitwardenShield } from "../icons";
++
+ import { AnonLayoutWrapperDataService } from "./anon-layout-wrapper-data.service";
+ 
+ export interface AnonLayoutWrapperData {
+@@ -160,7 +162,7 @@ export class AnonLayoutWrapperComponent implements OnInit, OnDestroy {
+   private resetPageData() {
+     this.pageTitle = null;
+     this.pageSubtitle = null;
+-    this.pageIcon = null;
++    this.pageIcon = BitwardenShield;
+     this.showReadonlyHostname = null;
+     this.maxWidth = null;
+     this.titleAreaMaxWidth = null;
+diff --git a/libs/auth/src/angular/anon-layout/anon-layout.component.html b/libs/auth/src/angular/anon-layout/anon-layout.component.html
+index cb3445abd9..3e5463cd71 100644
+--- a/libs/auth/src/angular/anon-layout/anon-layout.component.html
++++ b/libs/auth/src/angular/anon-layout/anon-layout.component.html
+@@ -8,7 +8,7 @@
+   <a
+     *ngIf="!hideLogo"
+     [routerLink]="['/']"
+-    class="tw-w-[128px] tw-block tw-mb-12 [&>*]:tw-align-top"
++    class="tw-w-[175px] tw-block tw-mb-12 [&>*]:tw-align-top"
+   >
+     <bit-icon [icon]="logo"></bit-icon>
+   </a>
+@@ -55,8 +55,14 @@
+       <ng-content select="[slot=environment-selector]"></ng-content>
+     </ng-container>
+     <ng-container *ngIf="!hideYearAndVersion">
+-      <div bitTypography="body2">&copy; {{ year }} Bitwarden Inc.</div>
++      <div bitTypography="body2">Vaultwarden Web</div>
+       <div bitTypography="body2">{{ version }}</div>
++      <br />
++      <div bitTypography="helper" id="vw-disclaimer">
++        A modified version of the Bitwarden&reg; Web Vault for Vaultwarden (an unofficial rewrite of
++        the Bitwarden&reg; server).<br />
++        Vaultwarden is not associated with the Bitwarden&reg; project nor Bitwarden Inc.
++      </div>
+     </ng-container>
+   </footer>
+ </main>
+diff --git a/libs/components/src/tw-theme.css b/libs/components/src/tw-theme.css
+index 0a5a66337a..af5f0fb57a 100644
+--- a/libs/components/src/tw-theme.css
++++ b/libs/components/src/tw-theme.css
+@@ -7,13 +7,13 @@
+   --color-background: 255 255 255;
+   --color-background-alt: 243 246 249;
+   --color-background-alt2: 23 92 219;
+-  --color-background-alt3: 26 65 172;
+-  --color-background-alt4: 2 15 102;
++  --color-background-alt3: 33 37 41; /* bg of menu panel */
++  --color-background-alt4: 16 18 21; /* bg of active menu item */
+ 
+   --color-primary-100: 219 229 246;
+-  --color-primary-300: 121 161 233;
+-  --color-primary-600: 23 93 220;
+-  --color-primary-700: 26 65 172;
++  --color-primary-300: 108 117 125; /* hover of menu items */
++  --color-primary-600: 18 82 163; /* color of links and buttons */
++  --color-primary-700: 13 60 119; /* hover of links and buttons */
+ 
+   --color-secondary-100: 230 233 239;
+   --color-secondary-300: 168 179 200;
+@@ -49,7 +49,7 @@
+   --color-text-alt2: 255 255 255;
+   --color-text-code: 192 17 118;
+ 
+-  --color-marketing-logo: 23 93 220;
++  --color-marketing-logo: 15 15 15; /* The Vaultwarden Logo */
+ 
+   --tw-ring-offset-color: #ffffff;
+ }
+diff --git a/libs/components/tailwind.config.js b/libs/components/tailwind.config.js
+index 2df648723f..be4e907625 100644
+--- a/libs/components/tailwind.config.js
++++ b/libs/components/tailwind.config.js
+@@ -7,7 +7,6 @@ config.content = [
+   "libs/vault/src/**/*.{html,ts,mdx}",
+   "apps/web/src/**/*.{html,ts,mdx}",
+   "apps/browser/src/**/*.{html,ts,mdx}",
+-  "bitwarden_license/bit-web/src/**/*.{html,ts,mdx}",
+   ".storybook/preview.tsx",
+ ];
+ config.safelist = [
+diff --git a/tailwind.config.js b/tailwind.config.js
+index 637c28a54e..7afcea4e65 100644
+--- a/tailwind.config.js
++++ b/tailwind.config.js
+@@ -10,7 +10,6 @@ config.content = [
+   "./libs/tools/send/send-ui/src/*.{html,ts,mdx}",
+   "./libs/vault/src/**/*.{html,ts,mdx}",
+   "./apps/web/src/**/*.{html,ts,mdx}",
+-  "./bitwarden_license/bit-web/src/**/*.{html,ts,mdx}",
+   "./.storybook/preview.js",
+ ];
+ config.safelist = [
+diff --git a/tsconfig.json b/tsconfig.json
+index efa2ff70e1..b1b5729aa7 100644
+--- a/tsconfig.json
++++ b/tsconfig.json
+@@ -58,9 +58,7 @@
+     "apps/browser/src/**/*",
+     "libs/*/src/**/*",
+     "libs/tools/send/**/src/**/*",
+-    "libs/tools/card/src/**/*",
+-    "bitwarden_license/bit-web/src/**/*",
+-    "bitwarden_license/bit-common/src/**/*"
++    "libs/tools/card/src/**/*"
+   ],
+   "exclude": [
+     "apps/web/src/**/*.spec.ts",

--- a/patches/v2025.1.2.patch
+++ b/patches/v2025.1.2.patch
@@ -717,6 +717,19 @@ index cb3445abd9..3e5463cd71 100644
      </ng-container>
    </footer>
  </main>
+diff --git a/libs/auth/src/angular/registration/registration-start/registration-start.component.html b/libs/auth/src/angular/registration/registration-start/registration-start.component.html
+index de3611a597..23a7324566 100644
+--- a/libs/auth/src/angular/registration/registration-start/registration-start.component.html
++++ b/libs/auth/src/angular/registration/registration-start/registration-start.component.html
+@@ -53,7 +53,7 @@
+       {{ "continue" | i18n }}
+     </button>
+ 
+-    <p bitTypography="helper" class="tw-text-main tw-text-xs tw-mb-0">
++    <p bitTypography="helper" class="tw-text-main tw-text-xs tw-mb-0" *ngIf="!isSelfHost">
+       {{ "byContinuingYouAgreeToThe" | i18n }}
+       <a
+         bitLink
 diff --git a/libs/components/src/tw-theme.css b/libs/components/src/tw-theme.css
 index 0a5a66337a..af5f0fb57a 100644
 --- a/libs/components/src/tw-theme.css

--- a/patches/v2025.1.2.patch
+++ b/patches/v2025.1.2.patch
@@ -86,7 +86,7 @@ index b3fac56c0b..796a1a817a 100644
          </bit-form-field>
        </div>
 diff --git a/apps/web/src/app/admin-console/organizations/settings/account.component.ts b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
-index f2834b6109..a48d24a982 100644
+index f2834b6109..117907171c 100644
 --- a/apps/web/src/app/admin-console/organizations/settings/account.component.ts
 +++ b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
 @@ -97,7 +97,7 @@ export class AccountComponent implements OnInit, OnDestroy {
@@ -98,14 +98,6 @@ index f2834b6109..a48d24a982 100644
  
      const userId = await firstValueFrom(getUserId(this.accountService.activeAccount$));
      this.route.params
-@@ -195,6 +195,7 @@ export class AccountComponent implements OnInit, OnDestroy {
-   };
- 
-   submitCollectionManagement = async () => {
-+    return; // flexible collections are not supported by Vaultwarden
-     const request = new OrganizationCollectionManagementUpdateRequest();
-     request.limitCollectionCreation =
-       this.collectionManagementFormGroup.value.limitCollectionCreation;
 diff --git a/apps/web/src/app/app.component.html b/apps/web/src/app/app.component.html
 index a39c045e0e..9d72e609b4 100644
 --- a/apps/web/src/app/app.component.html

--- a/patches/v2025.1.2.patch
+++ b/patches/v2025.1.2.patch
@@ -717,6 +717,18 @@ index cb3445abd9..3e5463cd71 100644
      </ng-container>
    </footer>
  </main>
+diff --git a/libs/auth/src/angular/login/login-secondary-content.component.ts b/libs/auth/src/angular/login/login-secondary-content.component.ts
+index b608542b37..4f0b86baa7 100644
+--- a/libs/auth/src/angular/login/login-secondary-content.component.ts
++++ b/libs/auth/src/angular/login/login-secondary-content.component.ts
+@@ -11,7 +11,6 @@ import { LinkModule } from "@bitwarden/components";
+   imports: [CommonModule, JslibModule, LinkModule, RouterModule],
+   template: `
+     <div class="tw-text-center" *ngIf="!(isUserRegistrationDisabled$ | async)">
+-      {{ "newToBitwarden" | i18n }}
+       <a bitLink routerLink="/signup">{{ "createAccount" | i18n }}</a>
+     </div>
+   `,
 diff --git a/libs/auth/src/angular/registration/registration-start/registration-start.component.html b/libs/auth/src/angular/registration/registration-start/registration-start.component.html
 index de3611a597..23a7324566 100644
 --- a/libs/auth/src/angular/registration/registration-start/registration-start.component.html

--- a/patches/v2025.1.2.patch
+++ b/patches/v2025.1.2.patch
@@ -14,22 +14,6 @@ index e64ef6ebeb..b41ca4219d 100644
    "dev": {
      "port": 8080,
      "allowedHosts": "auto"
-diff --git a/apps/web/package.json b/apps/web/package.json
-index 7047b0fb13..b3b629248b 100644
---- a/apps/web/package.json
-+++ b/apps/web/package.json
-@@ -3,11 +3,8 @@
-   "version": "2025.1.2",
-   "scripts": {
-     "build:oss": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" webpack",
--    "build:bit": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" webpack -c ../../bitwarden_license/bit-web/webpack.config.js",
-     "build:oss:watch": "webpack serve",
--    "build:bit:watch": "webpack serve -c ../../bitwarden_license/bit-web/webpack.config.js",
-     "build:bit:dev": "cross-env ENV=development npm run build:bit",
--    "build:bit:dev:analyze": "cross-env LOGGING=false webpack -c ../../bitwarden_license/bit-web/webpack.config.js --profile --json > stats.json && npx webpack-bundle-analyzer stats.json build/",
-     "build:bit:dev:watch": "cross-env ENV=development NODE_OPTIONS=\"--max-old-space-size=8192\" npm run build:bit:watch",
-     "build:bit:qa": "cross-env NODE_ENV=production ENV=qa npm run build:bit",
-     "build:bit:euprd": "cross-env NODE_ENV=production ENV=euprd npm run build:bit",
 diff --git a/apps/web/src/app/admin-console/organizations/create/organization-information.component.html b/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
 index e0a8006081..789efd9264 100644
 --- a/apps/web/src/app/admin-console/organizations/create/organization-information.component.html

--- a/patches/v2025.2.1.patch
+++ b/patches/v2025.2.1.patch
@@ -1,0 +1,799 @@
+diff --git a/apps/web/config/base.json b/apps/web/config/base.json
+index e64ef6ebeb..b41ca4219d 100644
+--- a/apps/web/config/base.json
++++ b/apps/web/config/base.json
+@@ -1,11 +1,5 @@
+ {
+   "urls": {},
+-  "stripeKey": "pk_test_KPoCfZXu7mznb9uSCPZ2JpTD",
+-  "braintreeKey": "sandbox_r72q8jq6_9pnxkwm75f87sdc2",
+-  "paypal": {
+-    "businessId": "AD3LAUZSNVPJY",
+-    "buttonAction": "https://www.sandbox.paypal.com/cgi-bin/webscr"
+-  },
+   "dev": {
+     "port": 8080,
+     "allowedHosts": "auto"
+diff --git a/apps/web/src/app/admin-console/organizations/create/organization-information.component.html b/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
+index e0a8006081..789efd9264 100644
+--- a/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
++++ b/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
+@@ -12,7 +12,7 @@
+       <input bitInput type="text" formControlName="name" />
+     </bit-form-field>
+     <bit-form-field class="tw-w-1/2">
+-      <bit-label>{{ "billingEmail" | i18n }}</bit-label>
++      <bit-label>{{ "email" | i18n }}</bit-label>
+       <input bitInput type="email" formControlName="billingEmail" />
+     </bit-form-field>
+     <bit-form-field class="tw-w-1/2" *ngIf="isProvider">
+diff --git a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
+index 1f31ae4fc0..396be3a614 100644
+--- a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
++++ b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
+@@ -162,6 +162,7 @@ export class OrganizationLayoutComponent implements OnInit {
+   }
+ 
+   canShowBillingTab(organization: Organization): boolean {
++    return false; // disable billing tab in Vaultwarden
+     return canAccessBillingTab(organization);
+   }
+ 
+diff --git a/apps/web/src/app/admin-console/organizations/members/members.component.ts b/apps/web/src/app/admin-console/organizations/members/members.component.ts
+index df4517942f..b1c86af1bc 100644
+--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
++++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
+@@ -211,11 +211,7 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
+             .find((p) => p.organizationId === this.organization.id);
+           this.orgResetPasswordPolicyEnabled = resetPasswordPolicy?.enabled;
+ 
+-          const billingMetadata = await this.billingApiService.getOrganizationBillingMetadata(
+-            this.organization.id,
+-          );
+-
+-          this.orgIsOnSecretsManagerStandalone = billingMetadata.isOnSecretsManagerStandalone;
++          this.orgIsOnSecretsManagerStandalone = false; // don't get billing metadata
+ 
+           await this.load();
+ 
+diff --git a/apps/web/src/app/admin-console/organizations/settings/account.component.html b/apps/web/src/app/admin-console/organizations/settings/account.component.html
+index ae1ecb6f3b..5cbb2d0d84 100644
+--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
++++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
+@@ -16,7 +16,7 @@
+           <input bitInput id="orgName" type="text" formControlName="orgName" />
+         </bit-form-field>
+         <bit-form-field>
+-          <bit-label>{{ "billingEmail" | i18n }}</bit-label>
++          <bit-label>{{ "email" | i18n }}</bit-label>
+           <input bitInput id="billingEmail" formControlName="billingEmail" type="email" />
+         </bit-form-field>
+       </div>
+diff --git a/apps/web/src/app/admin-console/organizations/settings/account.component.ts b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+index 57892442c1..299b336d3f 100644
+--- a/apps/web/src/app/admin-console/organizations/settings/account.component.ts
++++ b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+@@ -103,7 +103,7 @@ export class AccountComponent implements OnInit, OnDestroy {
+   ) {}
+ 
+   async ngOnInit() {
+-    this.selfHosted = this.platformUtilsService.isSelfHost();
++    this.selfHosted = false; // set to false so we can rename organizations
+ 
+     this.configService
+       .getFeatureFlag$(FeatureFlag.LimitItemDeletion)
+diff --git a/apps/web/src/app/app.component.html b/apps/web/src/app/app.component.html
+index a39c045e0e..9d72e609b4 100644
+--- a/apps/web/src/app/app.component.html
++++ b/apps/web/src/app/app.component.html
+@@ -3,7 +3,7 @@
+    when the body has the layout_frontend class. Having this match the index allows for a duplicative yet seamless
+    loading state here for process reloading. -->
+   <div class="tw-p-8 tw-flex">
+-    <img class="new-logo-themed" alt="Bitwarden" />
++    <img class="new-logo-themed" alt="Vaultwarden" />
+     <div class="spinner-container tw-justify-center">
+       <i
+         class="bwi bwi-spinner bwi-spin bwi-3x tw-text-muted"
+diff --git a/apps/web/src/app/app.component.ts b/apps/web/src/app/app.component.ts
+index 2b87ffda53..b74230ca0b 100644
+--- a/apps/web/src/app/app.component.ts
++++ b/apps/web/src/app/app.component.ts
+@@ -193,6 +193,10 @@ export class AppComponent implements OnDestroy, OnInit {
+             break;
+           }
+           case "showToast":
++            if (typeof message.text === "string" && typeof crypto.subtle === "undefined") {
++              message.title = "This browser requires HTTPS to use the web vault";
++              message.text = "Check the Vaultwarden wiki for details on how to enable it";
++            }
+             this.toastService._showToast(message);
+             break;
+           case "convertAccountToKeyConnector":
+diff --git a/apps/web/src/app/auth/settings/change-password.component.html b/apps/web/src/app/auth/settings/change-password.component.html
+index 91144fdfc1..d3dc4410c9 100644
+--- a/apps/web/src/app/auth/settings/change-password.component.html
++++ b/apps/web/src/app/auth/settings/change-password.component.html
+@@ -125,5 +125,3 @@
+     {{ "changeMasterPassword" | i18n }}
+   </button>
+ </form>
+-
+-<app-webauthn-login-settings></app-webauthn-login-settings>
+diff --git a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
+index de187d2c33..c33f49fd70 100644
+--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
++++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
+@@ -189,11 +189,11 @@ export class TwoFactorSetupAuthenticatorComponent
+     new window.QRious({
+       element: document.getElementById("qr"),
+       value:
+-        "otpauth://totp/Bitwarden:" +
++        "otpauth://totp/Vaultwarden:" +
+         Utils.encodeRFC3986URIComponent(email) +
+         "?secret=" +
+         encodeURIComponent(this.key) +
+-        "&issuer=Bitwarden",
++        "&issuer=Vaultwarden",
+       size: 160,
+     });
+   }
+diff --git a/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts b/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
+index d533badabf..6512ecbd13 100644
+--- a/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
++++ b/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
+@@ -54,6 +54,7 @@ export class OrgBillingHistoryViewComponent implements OnInit, OnDestroy {
+ 
+     this.loading = true;
+ 
++    /* disable billing history
+     const openInvoicesPromise = this.organizationBillingApiService.getBillingInvoices(
+       this.organizationId,
+       "open",
+@@ -87,6 +88,7 @@ export class OrgBillingHistoryViewComponent implements OnInit, OnDestroy {
+       openInvoices.length <= pageSize ||
+       paidInvoices.length <= pageSize ||
+       transactions.length <= pageSize;
++    */
+ 
+     this.loading = false;
+   }
+diff --git a/apps/web/src/app/billing/organizations/organization-plans.component.html b/apps/web/src/app/billing/organizations/organization-plans.component.html
+index 0a4eea57f9..6c01f631b9 100644
+--- a/apps/web/src/app/billing/organizations/organization-plans.component.html
++++ b/apps/web/src/app/billing/organizations/organization-plans.component.html
+@@ -6,7 +6,7 @@
+   ></i>
+   <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+ </ng-container>
+-<ng-container *ngIf="createOrganization && selfHosted">
++<ng-container *ngIf="createOrganization && false">
+   <ng-container *ngIf="!(useLicenseUploaderComponent$ | async)">
+     <p bitTypography="body1">{{ "uploadLicenseFileOrg" | i18n }}</p>
+     <form [formGroup]="selfHostedForm" [bitSubmit]="submit">
+@@ -40,12 +40,7 @@
+     (onLicenseFileUploaded)="onLicenseFileUploaded($event)"
+   />
+ </ng-container>
+-<form
+-  [formGroup]="formGroup"
+-  [bitSubmit]="submit"
+-  *ngIf="!loading && !selfHosted && this.passwordManagerPlans && this.secretsManagerPlans"
+-  class="tw-pt-6"
+->
++<form [formGroup]="formGroup" [bitSubmit]="submit" *ngIf="!loading" class="tw-pt-6">
+   <bit-section [ngClass]="{ 'tw-hidden': !createOrganization }">
+     <app-org-info
+       (changedBusinessOwned)="changedOwnedBusiness()"
+diff --git a/apps/web/src/app/billing/organizations/organization-plans.component.ts b/apps/web/src/app/billing/organizations/organization-plans.component.ts
+index 071d1f7516..41380d2d33 100644
+--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
++++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
+@@ -194,13 +194,12 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+           .organizations$(userId)
+           .pipe(getOrganizationById(this.organizationId)),
+       );
+-      this.billing = await this.organizationApiService.getBilling(this.organizationId);
+-      this.sub = await this.organizationApiService.getSubscription(this.organizationId);
+-      this.taxInformation = await this.organizationApiService.getTaxInfo(this.organizationId);
+-    } else if (!this.selfHosted) {
+-      this.taxInformation = await this.apiService.getTaxInfo();
++      this.billing = null; // no billing in Vaultwarden
++      this.sub = null; // no subscriptions in Vaultwarden;
++      this.taxInformation = null; // no taxes in Vaultwarden;
+     }
+ 
++    /* no need to ask /api/plans because Vaultwarden only supports the free plan
+     if (!this.selfHosted) {
+       const plans = await this.apiService.getPlans();
+       this.passwordManagerPlans = plans.data.filter((plan) => !!plan.PasswordManager);
+@@ -236,6 +235,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+       this.plan = providerDefaultPlan.type;
+       this.productTier = providerDefaultPlan.productTier;
+     }
++    end of asking /api/plans in Vaultwarden */
+ 
+     if (!this.createOrganization) {
+       this.upgradeFlowPrefillForm();
+@@ -285,6 +285,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get upgradeRequiresPaymentMethod() {
++    return false; // Vaultwarden is always free
+     return (
+       this.organization?.productTierType === ProductTierType.Free &&
+       !this.showFree &&
+@@ -320,6 +321,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get selectableProducts() {
++    return null; // there are no products to select in Vaultwarden
+     if (this.acceptingSponsorship) {
+       const familyPlan = this.passwordManagerPlans.find(
+         (plan) => plan.type === PlanType.FamiliesAnnually,
+@@ -351,6 +353,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get selectablePlans() {
++    return null; // no plans to select in Vaultwarden
+     const selectedProductTierType = this.formGroup.controls.productTier.value;
+     const result =
+       this.passwordManagerPlans?.filter(
+@@ -481,6 +484,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get planOffersSecretsManager() {
++    return false; // no support for secrets manager in Vaultwarden
+     return this.selectedSecretsManagerPlan != null;
+   }
+ 
+@@ -489,6 +493,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   changedProduct() {
++    return; // no choice of products in Vaultwarden
+     const selectedPlan = this.selectablePlans[0];
+ 
+     this.setPlanType(selectedPlan.type);
+@@ -617,9 +622,8 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+         const collectionCt = collection.encryptedString;
+         const orgKeys = await this.keyService.makeKeyPair(orgKey[1]);
+ 
+-        orgId = this.selfHosted
+-          ? await this.createSelfHosted(key, collectionCt, orgKeys)
+-          : await this.createCloudHosted(key, collectionCt, orgKeys, orgKey[1]);
++        // always use createCloudHosted() to disable license file upload
++        orgId = await this.createCloudHosted(key, collectionCt, orgKeys, orgKey[1]);
+ 
+         this.toastService.showToast({
+           variant: "success",
+@@ -767,7 +771,9 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+     request.billingEmail = this.formGroup.controls.billingEmail.value;
+     request.initiationPath = "New organization creation in-product";
+     request.keys = new OrganizationKeysRequest(orgKeys[0], orgKeys[1].encryptedString);
++    request.planType = PlanType.Free; // always select the free plan in Vaultwarden
+ 
++    /* there is no plan to select in Vaultwarden
+     if (this.selectedPlan.type === PlanType.Free) {
+       request.planType = PlanType.Free;
+     } else {
+@@ -792,6 +798,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+ 
+     // Secrets Manager
+     this.buildSecretsManagerRequest(request);
++    end plan selection and no support for secret manager in Vaultwarden */
+ 
+     if (this.hasProvider) {
+       const providerRequest = new ProviderOrganizationCreateRequest(
+@@ -853,6 +860,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   private buildSecretsManagerRequest(
+     request: OrganizationCreateRequest | OrganizationUpgradeRequest,
+   ): void {
++    return; // Vaultwarden does not support SecretsManager
+     const formValues = this.secretsManagerForm.value;
+ 
+     request.useSecretsManager = this.planOffersSecretsManager && formValues.enabled;
+@@ -871,6 +879,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   private upgradeFlowPrefillForm() {
++    return; // Vaultwarden only supports free plan
+     if (this.acceptingSponsorship) {
+       this.formGroup.controls.productTier.setValue(ProductTierType.Families);
+       this.changedProduct();
+diff --git a/apps/web/src/app/core/router.service.ts b/apps/web/src/app/core/router.service.ts
+index ff0aea47b9..21ec31a19a 100644
+--- a/apps/web/src/app/core/router.service.ts
++++ b/apps/web/src/app/core/router.service.ts
+@@ -61,7 +61,7 @@ export class RouterService {
+       .subscribe((event: NavigationEnd) => {
+         this.currentUrl = event.url;
+ 
+-        let title = i18nService.t("bitWebVault");
++        let title = "Vaultwarden Web";
+ 
+         if (this.currentUrl.includes("/sm/")) {
+           title = i18nService.t("bitSecretsManager");
+diff --git a/apps/web/src/app/core/web-platform-utils.service.ts b/apps/web/src/app/core/web-platform-utils.service.ts
+index 3df2a7d895..f73d811690 100644
+--- a/apps/web/src/app/core/web-platform-utils.service.ts
++++ b/apps/web/src/app/core/web-platform-utils.service.ts
+@@ -135,14 +135,17 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
+   }
+ 
+   isDev(): boolean {
++    return false; // treat Vaultwarden as production ready
+     return process.env.NODE_ENV === "development";
+   }
+ 
+   isSelfHost(): boolean {
++    return true; // treat Vaultwarden as self hosted
+     return WebPlatformUtilsService.isSelfHost();
+   }
+ 
+   static isSelfHost(): boolean {
++    return true; // treat Vaultwarden as self hosted
+     return process.env.ENV.toString() === "selfhosted";
+   }
+ 
+diff --git a/apps/web/src/app/layouts/frontend-layout.component.html b/apps/web/src/app/layouts/frontend-layout.component.html
+index d19af54f5d..03c8edf631 100644
+--- a/apps/web/src/app/layouts/frontend-layout.component.html
++++ b/apps/web/src/app/layouts/frontend-layout.component.html
+@@ -3,6 +3,12 @@
+ <footer class="tw-text-center tw-my-12">
+   <environment-selector></environment-selector>
+ 
+-  <div bitTypography="body2">&copy; {{ year }} Bitwarden Inc.</div>
++  <div bitTypography="body2">Vaultwarden Web</div>
+   <div bitTypography="body2">{{ version }}</div>
++  <br />
++  <div bitTypography="helper" id="vw-disclaimer">
++    A modified version of the Bitwarden&reg; Web Vault for Vaultwarden (an unofficial rewrite of the
++    Bitwarden&reg; server).<br />
++    Vaultwarden is not associated with the Bitwarden&reg; project nor Bitwarden Inc.
++  </div>
+ </footer>
+diff --git a/apps/web/src/app/layouts/header/web-header.component.html b/apps/web/src/app/layouts/header/web-header.component.html
+index 7cba19b29a..024b14daad 100644
+--- a/apps/web/src/app/layouts/header/web-header.component.html
++++ b/apps/web/src/app/layouts/header/web-header.component.html
+@@ -61,7 +61,12 @@
+                 <i class="bwi bwi-fw bwi-user" aria-hidden="true"></i>
+                 {{ "accountSettings" | i18n }}
+               </a>
+-              <a bitMenuItem href="https://bitwarden.com/help/" target="_blank" rel="noreferrer">
++              <a
++                bitMenuItem
++                href="https://github.com/dani-garcia/vaultwarden"
++                target="_blank"
++                rel="noreferrer"
++              >
+                 <i class="bwi bwi-fw bwi-question-circle" aria-hidden="true"></i>
+                 {{ "getHelp" | i18n }}
+               </a>
+diff --git a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
+index 08195d95bf..f51a216a14 100644
+--- a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
++++ b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
+@@ -10,10 +10,7 @@
+   >
+   </bit-nav-item>
+   <ng-container *ngIf="moreProducts$ | async as moreProducts">
+-    <section
+-      *ngIf="moreProducts.length > 0"
+-      class="tw-mt-2 tw-flex tw-w-full tw-flex-col tw-gap-2 tw-border-0"
+-    >
++    <section *ngIf="false" class="tw-mt-2 tw-flex tw-w-full tw-flex-col tw-gap-2 tw-border-0">
+       <span class="tw-text-xs !tw-text-alt2 tw-p-2 tw-pb-0">{{ "moreFromBitwarden" | i18n }}</span>
+       <ng-container *ngFor="let more of moreProducts">
+         <!-- <a> for when the marketing route is external -->
+diff --git a/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html b/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
+index 204737eee2..9bee4f6e03 100644
+--- a/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
++++ b/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
+@@ -30,7 +30,7 @@
+ 
+     <!-- Other options -->
+     <section
+-      *ngIf="products.other.length > 0"
++      *ngIf="false"
+       class="tw-mt-4 tw-flex tw-w-full tw-flex-col tw-gap-2 tw-border-0 tw-border-t tw-border-solid tw-border-t-text-muted tw-p-2 tw-pb-0"
+     >
+       <span class="tw-mb-1 tw-text-xs tw-text-muted">{{ "moreFromBitwarden" | i18n }}</span>
+diff --git a/apps/web/src/app/layouts/user-layout.component.ts b/apps/web/src/app/layouts/user-layout.component.ts
+index e859993af3..125b53fdf1 100644
+--- a/apps/web/src/app/layouts/user-layout.component.ts
++++ b/apps/web/src/app/layouts/user-layout.component.ts
+@@ -3,7 +3,7 @@
+ import { CommonModule } from "@angular/common";
+ import { Component, OnInit } from "@angular/core";
+ import { RouterModule } from "@angular/router";
+-import { Observable, switchMap } from "rxjs";
++import { Observable, of } from "rxjs";
+ 
+ import { JslibModule } from "@bitwarden/angular/jslib.module";
+ import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+@@ -40,15 +40,14 @@ export class UserLayoutComponent implements OnInit {
+     private billingAccountProfileStateService: BillingAccountProfileStateService,
+     private accountService: AccountService,
+   ) {
+-    this.showSubscription$ = this.accountService.activeAccount$.pipe(
+-      switchMap((account) =>
+-        this.billingAccountProfileStateService.canViewSubscription$(account.id),
+-      ),
+-    );
++    this.showSubscription$ = of(false); // always hide subscriptions in Vaultwarden
+   }
+ 
+   async ngOnInit() {
+     document.body.classList.remove("layout_frontend");
+     await this.syncService.fullSync(false);
++
++    this.hasFamilySponsorshipAvailable$ = of(false); // disable family Sponsorships in Vaultwarden
++    this.showSponsoredFamilies$ = of(false); // disable family Sponsorships in Vaultwarden
+   }
+ }
+diff --git a/apps/web/src/app/platform/web-environment.service.ts b/apps/web/src/app/platform/web-environment.service.ts
+index 1df842d6b3..d61637c92e 100644
+--- a/apps/web/src/app/platform/web-environment.service.ts
++++ b/apps/web/src/app/platform/web-environment.service.ts
+@@ -38,7 +38,17 @@ export class WebEnvironmentService extends DefaultEnvironmentService {
+     super(stateProvider, accountService, additionalRegionConfigs);
+ 
+     // The web vault always uses the current location as the base url
+-    envUrls.base ??= this.win.location.origin;
++    // If the base URL is `https://vaultwarden.example.com/base/path/`,
++    // `window.location.href` should have one of the following forms:
++    //
++    // - `https://vaultwarden.example.com/base/path/`
++    // - `https://vaultwarden.example.com/base/path/#/some/route[?queryParam=...]`
++    // - `https://vaultwarden.example.com/base/path/?queryParam=...`
++    //
++    // We want to get to just `https://vaultwarden.example.com/base/path`.
++    let baseUrl = this.win.location.href;
++    baseUrl = baseUrl.replace(/(\/+|\/*#.*|\/*\?.*)$/, ""); // Strip off trailing `/`, `#`, `?` and everything after.
++    envUrls.base ??= baseUrl;
+ 
+     // Find the region
+     const currentHostname = new URL(this.win.location.href).hostname;
+diff --git a/apps/web/src/app/tools/send/add-edit.component.html b/apps/web/src/app/tools/send/add-edit.component.html
+index 7eade18a7c..b8f865faa7 100644
+--- a/apps/web/src/app/tools/send/add-edit.component.html
++++ b/apps/web/src/app/tools/send/add-edit.component.html
+@@ -230,7 +230,12 @@
+             <bit-label for="password" *ngIf="!hasPassword">{{ "password" | i18n }}</bit-label>
+             <bit-label for="password" *ngIf="hasPassword">{{ "newPassword" | i18n }}</bit-label>
+ 
+-            <input bitInput type="password" formControlName="password" />
++            <input
++              bitInput
++              type="password"
++              formControlName="password"
++              autocomplete="new-password"
++            />
+             <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
+             <bit-hint>{{ "sendPasswordDesc" | i18n }}</bit-hint>
+           </bit-form-field>
+diff --git a/apps/web/src/app/tools/send/send-access-explainer.component.html b/apps/web/src/app/tools/send/send-access-explainer.component.html
+index f56b68cc29..284b916514 100644
+--- a/apps/web/src/app/tools/send/send-access-explainer.component.html
++++ b/apps/web/src/app/tools/send/send-access-explainer.component.html
+@@ -1,18 +1,5 @@
+ <div class="tw-text-center tw-text-muted">
+   <p bitTypography="body2" class="tw-mb-0">
+     {{ "sendAccessTaglineProductDesc" | i18n }}
+-    {{ "sendAccessTaglineLearnMore" | i18n }}
+-    <a
+-      bitLink
+-      href="https://www.bitwarden.com/products/send?source=web-vault"
+-      target="_blank"
+-      rel="noreferrer"
+-      >Bitwarden Send</a
+-    >
+-    {{ "sendAccessTaglineOr" | i18n }}
+-    <a bitLink routerLink="/signup" target="_blank" rel="noreferrer">{{
+-      "sendAccessTaglineSignUp" | i18n
+-    }}</a>
+-    {{ "sendAccessTaglineTryToday" | i18n }}
+   </p>
+ </div>
+diff --git a/apps/web/src/index.html b/apps/web/src/index.html
+index 0b8ea86491..5d98411f46 100644
+--- a/apps/web/src/index.html
++++ b/apps/web/src/index.html
+@@ -5,19 +5,21 @@
+     <meta name="viewport" content="width=1010" />
+     <meta name="theme-color" content="#175DDC" />
+ 
+-    <title page-title>Bitwarden Web vault</title>
++    <title page-title>Vaultwarden Web</title>
+ 
+     <link rel="apple-touch-icon" sizes="180x180" href="images/icons/apple-touch-icon.png" />
+     <link rel="icon" type="image/png" sizes="32x32" href="images/icons/favicon-32x32.png" />
+     <link rel="icon" type="image/png" sizes="16x16" href="images/icons/favicon-16x16.png" />
+     <link rel="mask-icon" href="images/icons/safari-pinned-tab.svg" color="#175DDC" />
+     <link rel="manifest" href="manifest.json" />
++    <!-- webpackIgnore: true -->
++    <link rel="stylesheet" href="css/vaultwarden.css" />
+   </head>
+   <body class="layout_frontend">
+     <app-root>
+       <!-- Note: any changes to this html need to be made in the app.component.html as well -->
+       <div class="tw-p-8 tw-flex">
+-        <img class="new-logo-themed" alt="Bitwarden" />
++        <img class="new-logo-themed" alt="Vaultwarden" />
+         <div class="spinner-container tw-justify-center">
+           <i
+             class="bwi bwi-spinner bwi-spin bwi-3x tw-text-muted"
+diff --git a/apps/web/src/manifest.json b/apps/web/src/manifest.json
+index 92a1204c60..d9ff4771a3 100644
+--- a/apps/web/src/manifest.json
++++ b/apps/web/src/manifest.json
+@@ -1,5 +1,5 @@
+ {
+-  "name": "Bitwarden Vault",
++  "name": "Vaultwarden Web",
+   "icons": [
+     {
+       "src": "images/icons/android-chrome-192x192.png",
+@@ -12,6 +12,6 @@
+       "type": "image/png"
+     }
+   ],
+-  "theme_color": "#175DDC",
+-  "background_color": "#175DDC"
++  "theme_color": "#FFFFFF",
++  "background_color": "#FFFFFF"
+ }
+diff --git a/apps/web/src/scss/tailwind.css b/apps/web/src/scss/tailwind.css
+index 1ac7b15401..0c388f6787 100644
+--- a/apps/web/src/scss/tailwind.css
++++ b/apps/web/src/scss/tailwind.css
+@@ -52,7 +52,7 @@
+   img.new-logo-themed {
+     @apply tw-block;
+ 
+-    width: 128px;
++    width: 175px;
+   }
+   .theme_light img.new-logo-themed {
+     content: url("../images/logo.svg");
+diff --git a/apps/web/tailwind.config.js b/apps/web/tailwind.config.js
+index 4a3f6cfef1..8b1d6081a6 100644
+--- a/apps/web/tailwind.config.js
++++ b/apps/web/tailwind.config.js
+@@ -8,7 +8,6 @@ config.content = [
+   "../../libs/key-management-ui/src/**/*.{html,ts}",
+   "../../libs/vault/src/**/*.{html,ts}",
+   "../../libs/angular/src/**/*.{html,ts}",
+-  "../../bitwarden_license/bit-web/src/**/*.{html,ts}",
+ ];
+ 
+ module.exports = config;
+diff --git a/apps/web/tsconfig.json b/apps/web/tsconfig.json
+index 68ac8c8008..2b4af754f4 100644
+--- a/apps/web/tsconfig.json
++++ b/apps/web/tsconfig.json
+@@ -10,7 +10,6 @@
+       "@bitwarden/auth/angular": ["../../libs/auth/src/angular"],
+       "@bitwarden/auth/common": ["../../libs/auth/src/common"],
+       "@bitwarden/billing": ["../../libs/billing/src"],
+-      "@bitwarden/bit-common/*": ["../../bitwarden_license/bit-common/src/*"],
+       "@bitwarden/common/*": ["../../libs/common/src/*"],
+       "@bitwarden/components": ["../../libs/components/src"],
+       "@bitwarden/generator-components": ["../../libs/tools/generator/components/src"],
+diff --git a/clients.code-workspace b/clients.code-workspace
+index f7d86d2a24..75389727d2 100644
+--- a/clients.code-workspace
++++ b/clients.code-workspace
+@@ -8,18 +8,10 @@
+       "name": "web vault",
+       "path": "apps/web",
+     },
+-    {
+-      "name": "web vault (bit)",
+-      "path": "bitwarden_license/bit-web",
+-    },
+     {
+       "name": "cli",
+       "path": "apps/cli",
+     },
+-    {
+-      "name": "cli (bit)",
+-      "path": "bitwarden_license/bit-cli",
+-    },
+     {
+       "name": "desktop",
+       "path": "apps/desktop",
+@@ -32,10 +24,6 @@
+       "name": "libs",
+       "path": "libs",
+     },
+-    {
+-      "name": "common (bit)",
+-      "path": "bitwarden_license/bit-common",
+-    },
+   ],
+   "settings": {
+     "eslint.options": {
+diff --git a/jest.config.js b/jest.config.js
+index e8815f92ff..c635c2fc45 100644
+--- a/jest.config.js
++++ b/jest.config.js
+@@ -20,9 +20,6 @@ module.exports = {
+     "<rootDir>/apps/cli/jest.config.js",
+     "<rootDir>/apps/desktop/jest.config.js",
+     "<rootDir>/apps/web/jest.config.js",
+-    "<rootDir>/bitwarden_license/bit-web/jest.config.js",
+-    "<rootDir>/bitwarden_license/bit-cli/jest.config.js",
+-    "<rootDir>/bitwarden_license/bit-common/jest.config.js",
+ 
+     "<rootDir>/libs/admin-console/jest.config.js",
+     "<rootDir>/libs/angular/jest.config.js",
+diff --git a/libs/angular/src/auth/components/register.component.ts b/libs/angular/src/auth/components/register.component.ts
+index e4787aa8c0..1675a45a33 100644
+--- a/libs/angular/src/auth/components/register.component.ts
++++ b/libs/angular/src/auth/components/register.component.ts
+@@ -108,6 +108,14 @@ export class RegisterComponent extends CaptchaProtectedComponent implements OnIn
+   }
+ 
+   async submit(showToast = true) {
++    if (typeof crypto.subtle === "undefined") {
++      this.platformUtilsService.showToast(
++        "error",
++        "This browser requires HTTPS to use the web vault",
++        "Check the Vaultwarden wiki for details on how to enable it",
++      );
++      return;
++    }
+     let email = this.formGroup.value.email;
+     email = email.trim().toLowerCase();
+     let name = this.formGroup.value.name;
+diff --git a/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts b/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
+index 04dc3b6dfd..2791b0bc17 100644
+--- a/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
++++ b/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
+@@ -8,6 +8,8 @@ import { AnonLayoutComponent } from "@bitwarden/auth/angular";
+ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+ import { Icon, Translation } from "@bitwarden/components";
+ 
++import { BitwardenShield } from "../icons";
++
+ import { AnonLayoutWrapperDataService } from "./anon-layout-wrapper-data.service";
+ 
+ export interface AnonLayoutWrapperData {
+@@ -160,7 +162,7 @@ export class AnonLayoutWrapperComponent implements OnInit, OnDestroy {
+   private resetPageData() {
+     this.pageTitle = null;
+     this.pageSubtitle = null;
+-    this.pageIcon = null;
++    this.pageIcon = BitwardenShield;
+     this.showReadonlyHostname = null;
+     this.maxWidth = null;
+     this.titleAreaMaxWidth = null;
+diff --git a/libs/auth/src/angular/anon-layout/anon-layout.component.html b/libs/auth/src/angular/anon-layout/anon-layout.component.html
+index cb3445abd9..3e5463cd71 100644
+--- a/libs/auth/src/angular/anon-layout/anon-layout.component.html
++++ b/libs/auth/src/angular/anon-layout/anon-layout.component.html
+@@ -8,7 +8,7 @@
+   <a
+     *ngIf="!hideLogo"
+     [routerLink]="['/']"
+-    class="tw-w-[128px] tw-block tw-mb-12 [&>*]:tw-align-top"
++    class="tw-w-[175px] tw-block tw-mb-12 [&>*]:tw-align-top"
+   >
+     <bit-icon [icon]="logo"></bit-icon>
+   </a>
+@@ -55,8 +55,14 @@
+       <ng-content select="[slot=environment-selector]"></ng-content>
+     </ng-container>
+     <ng-container *ngIf="!hideYearAndVersion">
+-      <div bitTypography="body2">&copy; {{ year }} Bitwarden Inc.</div>
++      <div bitTypography="body2">Vaultwarden Web</div>
+       <div bitTypography="body2">{{ version }}</div>
++      <br />
++      <div bitTypography="helper" id="vw-disclaimer">
++        A modified version of the Bitwarden&reg; Web Vault for Vaultwarden (an unofficial rewrite of
++        the Bitwarden&reg; server).<br />
++        Vaultwarden is not associated with the Bitwarden&reg; project nor Bitwarden Inc.
++      </div>
+     </ng-container>
+   </footer>
+ </main>
+diff --git a/libs/auth/src/angular/login/login-secondary-content.component.ts b/libs/auth/src/angular/login/login-secondary-content.component.ts
+index b608542b37..4f0b86baa7 100644
+--- a/libs/auth/src/angular/login/login-secondary-content.component.ts
++++ b/libs/auth/src/angular/login/login-secondary-content.component.ts
+@@ -11,7 +11,6 @@ import { LinkModule } from "@bitwarden/components";
+   imports: [CommonModule, JslibModule, LinkModule, RouterModule],
+   template: `
+     <div class="tw-text-center" *ngIf="!(isUserRegistrationDisabled$ | async)">
+-      {{ "newToBitwarden" | i18n }}
+       <a bitLink routerLink="/signup">{{ "createAccount" | i18n }}</a>
+     </div>
+   `,
+diff --git a/libs/auth/src/angular/registration/registration-start/registration-start.component.html b/libs/auth/src/angular/registration/registration-start/registration-start.component.html
+index de3611a597..23a7324566 100644
+--- a/libs/auth/src/angular/registration/registration-start/registration-start.component.html
++++ b/libs/auth/src/angular/registration/registration-start/registration-start.component.html
+@@ -53,7 +53,7 @@
+       {{ "continue" | i18n }}
+     </button>
+ 
+-    <p bitTypography="helper" class="tw-text-main tw-text-xs tw-mb-0">
++    <p bitTypography="helper" class="tw-text-main tw-text-xs tw-mb-0" *ngIf="!isSelfHost">
+       {{ "byContinuingYouAgreeToThe" | i18n }}
+       <a
+         bitLink
+diff --git a/libs/components/src/tw-theme.css b/libs/components/src/tw-theme.css
+index 0a5a66337a..af5f0fb57a 100644
+--- a/libs/components/src/tw-theme.css
++++ b/libs/components/src/tw-theme.css
+@@ -7,13 +7,13 @@
+   --color-background: 255 255 255;
+   --color-background-alt: 243 246 249;
+   --color-background-alt2: 23 92 219;
+-  --color-background-alt3: 26 65 172;
+-  --color-background-alt4: 2 15 102;
++  --color-background-alt3: 33 37 41; /* bg of menu panel */
++  --color-background-alt4: 16 18 21; /* bg of active menu item */
+ 
+   --color-primary-100: 219 229 246;
+-  --color-primary-300: 121 161 233;
+-  --color-primary-600: 23 93 220;
+-  --color-primary-700: 26 65 172;
++  --color-primary-300: 108 117 125; /* hover of menu items */
++  --color-primary-600: 18 82 163; /* color of links and buttons */
++  --color-primary-700: 13 60 119; /* hover of links and buttons */
+ 
+   --color-secondary-100: 230 233 239;
+   --color-secondary-300: 168 179 200;
+@@ -49,7 +49,7 @@
+   --color-text-alt2: 255 255 255;
+   --color-text-code: 192 17 118;
+ 
+-  --color-marketing-logo: 23 93 220;
++  --color-marketing-logo: 15 15 15; /* The Vaultwarden Logo */
+ 
+   --tw-ring-offset-color: #ffffff;
+ }
+diff --git a/libs/components/tailwind.config.js b/libs/components/tailwind.config.js
+index 2df648723f..be4e907625 100644
+--- a/libs/components/tailwind.config.js
++++ b/libs/components/tailwind.config.js
+@@ -7,7 +7,6 @@ config.content = [
+   "libs/vault/src/**/*.{html,ts,mdx}",
+   "apps/web/src/**/*.{html,ts,mdx}",
+   "apps/browser/src/**/*.{html,ts,mdx}",
+-  "bitwarden_license/bit-web/src/**/*.{html,ts,mdx}",
+   ".storybook/preview.tsx",
+ ];
+ config.safelist = [
+diff --git a/tailwind.config.js b/tailwind.config.js
+index 637c28a54e..7afcea4e65 100644
+--- a/tailwind.config.js
++++ b/tailwind.config.js
+@@ -10,7 +10,6 @@ config.content = [
+   "./libs/tools/send/send-ui/src/*.{html,ts,mdx}",
+   "./libs/vault/src/**/*.{html,ts,mdx}",
+   "./apps/web/src/**/*.{html,ts,mdx}",
+-  "./bitwarden_license/bit-web/src/**/*.{html,ts,mdx}",
+   "./.storybook/preview.js",
+ ];
+ config.safelist = [
+diff --git a/tsconfig.json b/tsconfig.json
+index e6e4c47096..462adb62bc 100644
+--- a/tsconfig.json
++++ b/tsconfig.json
+@@ -58,9 +58,7 @@
+     "apps/browser/src/**/*",
+     "libs/*/src/**/*",
+     "libs/tools/send/**/src/**/*",
+-    "libs/tools/card/src/**/*",
+-    "bitwarden_license/bit-web/src/**/*",
+-    "bitwarden_license/bit-common/src/**/*"
++    "libs/tools/card/src/**/*"
+   ],
+   "exclude": [
+     "apps/web/src/**/*.spec.ts",

--- a/patches/v2025.2.2.patch
+++ b/patches/v2025.2.2.patch
@@ -1,0 +1,789 @@
+diff --git a/apps/web/config/base.json b/apps/web/config/base.json
+index e64ef6ebeb..b41ca4219d 100644
+--- a/apps/web/config/base.json
++++ b/apps/web/config/base.json
+@@ -1,11 +1,5 @@
+ {
+   "urls": {},
+-  "stripeKey": "pk_test_KPoCfZXu7mznb9uSCPZ2JpTD",
+-  "braintreeKey": "sandbox_r72q8jq6_9pnxkwm75f87sdc2",
+-  "paypal": {
+-    "businessId": "AD3LAUZSNVPJY",
+-    "buttonAction": "https://www.sandbox.paypal.com/cgi-bin/webscr"
+-  },
+   "dev": {
+     "port": 8080,
+     "allowedHosts": "auto"
+diff --git a/apps/web/src/app/admin-console/organizations/create/organization-information.component.html b/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
+index e0a8006081..789efd9264 100644
+--- a/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
++++ b/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
+@@ -12,7 +12,7 @@
+       <input bitInput type="text" formControlName="name" />
+     </bit-form-field>
+     <bit-form-field class="tw-w-1/2">
+-      <bit-label>{{ "billingEmail" | i18n }}</bit-label>
++      <bit-label>{{ "email" | i18n }}</bit-label>
+       <input bitInput type="email" formControlName="billingEmail" />
+     </bit-form-field>
+     <bit-form-field class="tw-w-1/2" *ngIf="isProvider">
+diff --git a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
+index 4485396b80..03f16f7264 100644
+--- a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
++++ b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
+@@ -159,6 +159,7 @@ export class OrganizationLayoutComponent implements OnInit {
+   }
+ 
+   canShowBillingTab(organization: Organization): boolean {
++    return false; // disable billing tab in Vaultwarden
+     return canAccessBillingTab(organization);
+   }
+ 
+diff --git a/apps/web/src/app/admin-console/organizations/members/members.component.ts b/apps/web/src/app/admin-console/organizations/members/members.component.ts
+index df4517942f..b1c86af1bc 100644
+--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
++++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
+@@ -211,11 +211,7 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
+             .find((p) => p.organizationId === this.organization.id);
+           this.orgResetPasswordPolicyEnabled = resetPasswordPolicy?.enabled;
+ 
+-          const billingMetadata = await this.billingApiService.getOrganizationBillingMetadata(
+-            this.organization.id,
+-          );
+-
+-          this.orgIsOnSecretsManagerStandalone = billingMetadata.isOnSecretsManagerStandalone;
++          this.orgIsOnSecretsManagerStandalone = false; // don't get billing metadata
+ 
+           await this.load();
+ 
+diff --git a/apps/web/src/app/admin-console/organizations/settings/account.component.html b/apps/web/src/app/admin-console/organizations/settings/account.component.html
+index ae1ecb6f3b..5cbb2d0d84 100644
+--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
++++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
+@@ -16,7 +16,7 @@
+           <input bitInput id="orgName" type="text" formControlName="orgName" />
+         </bit-form-field>
+         <bit-form-field>
+-          <bit-label>{{ "billingEmail" | i18n }}</bit-label>
++          <bit-label>{{ "email" | i18n }}</bit-label>
+           <input bitInput id="billingEmail" formControlName="billingEmail" type="email" />
+         </bit-form-field>
+       </div>
+diff --git a/apps/web/src/app/admin-console/organizations/settings/account.component.ts b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+index 57892442c1..299b336d3f 100644
+--- a/apps/web/src/app/admin-console/organizations/settings/account.component.ts
++++ b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+@@ -103,7 +103,7 @@ export class AccountComponent implements OnInit, OnDestroy {
+   ) {}
+ 
+   async ngOnInit() {
+-    this.selfHosted = this.platformUtilsService.isSelfHost();
++    this.selfHosted = false; // set to false so we can rename organizations
+ 
+     this.configService
+       .getFeatureFlag$(FeatureFlag.LimitItemDeletion)
+diff --git a/apps/web/src/app/app.component.html b/apps/web/src/app/app.component.html
+index 471d89be1c..110a55538b 100644
+--- a/apps/web/src/app/app.component.html
++++ b/apps/web/src/app/app.component.html
+@@ -3,7 +3,7 @@
+    when the body has the layout_frontend class. Having this match the index allows for a duplicative yet seamless
+    loading state here for process reloading. -->
+   <div class="tw-p-8 tw-flex">
+-    <img class="new-logo-themed" alt="Bitwarden" />
++    <img class="new-logo-themed" alt="Vaultwarden" />
+     <div class="spinner-container tw-justify-center">
+       <i
+         class="bwi bwi-spinner bwi-spin bwi-3x tw-text-muted"
+diff --git a/apps/web/src/app/app.component.ts b/apps/web/src/app/app.component.ts
+index fe92cdcd3a..1ff560fe23 100644
+--- a/apps/web/src/app/app.component.ts
++++ b/apps/web/src/app/app.component.ts
+@@ -194,6 +194,10 @@ export class AppComponent implements OnDestroy, OnInit {
+             break;
+           }
+           case "showToast":
++            if (typeof message.text === "string" && typeof crypto.subtle === "undefined") {
++              message.title = "This browser requires HTTPS to use the web vault";
++              message.text = "Check the Vaultwarden wiki for details on how to enable it";
++            }
+             this.toastService._showToast(message);
+             break;
+           case "convertAccountToKeyConnector":
+diff --git a/apps/web/src/app/auth/settings/change-password.component.html b/apps/web/src/app/auth/settings/change-password.component.html
+index 91144fdfc1..d3dc4410c9 100644
+--- a/apps/web/src/app/auth/settings/change-password.component.html
++++ b/apps/web/src/app/auth/settings/change-password.component.html
+@@ -125,5 +125,3 @@
+     {{ "changeMasterPassword" | i18n }}
+   </button>
+ </form>
+-
+-<app-webauthn-login-settings></app-webauthn-login-settings>
+diff --git a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
+index de187d2c33..c33f49fd70 100644
+--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
++++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
+@@ -189,11 +189,11 @@ export class TwoFactorSetupAuthenticatorComponent
+     new window.QRious({
+       element: document.getElementById("qr"),
+       value:
+-        "otpauth://totp/Bitwarden:" +
++        "otpauth://totp/Vaultwarden:" +
+         Utils.encodeRFC3986URIComponent(email) +
+         "?secret=" +
+         encodeURIComponent(this.key) +
+-        "&issuer=Bitwarden",
++        "&issuer=Vaultwarden",
+       size: 160,
+     });
+   }
+diff --git a/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts b/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
+index d533badabf..6512ecbd13 100644
+--- a/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
++++ b/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
+@@ -54,6 +54,7 @@ export class OrgBillingHistoryViewComponent implements OnInit, OnDestroy {
+ 
+     this.loading = true;
+ 
++    /* disable billing history
+     const openInvoicesPromise = this.organizationBillingApiService.getBillingInvoices(
+       this.organizationId,
+       "open",
+@@ -87,6 +88,7 @@ export class OrgBillingHistoryViewComponent implements OnInit, OnDestroy {
+       openInvoices.length <= pageSize ||
+       paidInvoices.length <= pageSize ||
+       transactions.length <= pageSize;
++    */
+ 
+     this.loading = false;
+   }
+diff --git a/apps/web/src/app/billing/organizations/organization-plans.component.html b/apps/web/src/app/billing/organizations/organization-plans.component.html
+index 263ef12ebe..f574d83d67 100644
+--- a/apps/web/src/app/billing/organizations/organization-plans.component.html
++++ b/apps/web/src/app/billing/organizations/organization-plans.component.html
+@@ -6,17 +6,12 @@
+   ></i>
+   <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+ </ng-container>
+-<ng-container *ngIf="createOrganization && selfHosted">
++<ng-container *ngIf="createOrganization && false">
+   <organization-self-hosting-license-uploader
+     (onLicenseFileUploaded)="onLicenseFileUploaded($event)"
+   />
+ </ng-container>
+-<form
+-  [formGroup]="formGroup"
+-  [bitSubmit]="submit"
+-  *ngIf="!loading && !selfHosted && this.passwordManagerPlans && this.secretsManagerPlans"
+-  class="tw-pt-6"
+->
++<form [formGroup]="formGroup" [bitSubmit]="submit" *ngIf="!loading" class="tw-pt-6">
+   <bit-section [ngClass]="{ 'tw-hidden': !createOrganization }">
+     <app-org-info
+       (changedBusinessOwned)="changedOwnedBusiness()"
+diff --git a/apps/web/src/app/billing/organizations/organization-plans.component.ts b/apps/web/src/app/billing/organizations/organization-plans.component.ts
+index 84f2467b1b..e7a4ad1687 100644
+--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
++++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
+@@ -190,13 +190,12 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+           .organizations$(userId)
+           .pipe(getOrganizationById(this.organizationId)),
+       );
+-      this.billing = await this.organizationApiService.getBilling(this.organizationId);
+-      this.sub = await this.organizationApiService.getSubscription(this.organizationId);
+-      this.taxInformation = await this.organizationApiService.getTaxInfo(this.organizationId);
+-    } else if (!this.selfHosted) {
+-      this.taxInformation = await this.apiService.getTaxInfo();
++      this.billing = null; // no billing in Vaultwarden
++      this.sub = null; // no subscriptions in Vaultwarden;
++      this.taxInformation = null; // no taxes in Vaultwarden;
+     }
+ 
++    /* no need to ask /api/plans because Vaultwarden only supports the free plan
+     if (!this.selfHosted) {
+       const plans = await this.apiService.getPlans();
+       this.passwordManagerPlans = plans.data.filter((plan) => !!plan.PasswordManager);
+@@ -232,6 +231,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+       this.plan = providerDefaultPlan.type;
+       this.productTier = providerDefaultPlan.productTier;
+     }
++    end of asking /api/plans in Vaultwarden */
+ 
+     if (!this.createOrganization) {
+       this.upgradeFlowPrefillForm();
+@@ -289,6 +289,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get upgradeRequiresPaymentMethod() {
++    return false; // Vaultwarden is always free
+     return (
+       this.organization?.productTierType === ProductTierType.Free &&
+       !this.showFree &&
+@@ -324,6 +325,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get selectableProducts() {
++    return null; // there are no products to select in Vaultwarden
+     if (this.acceptingSponsorship) {
+       const familyPlan = this.passwordManagerPlans.find(
+         (plan) => plan.type === PlanType.FamiliesAnnually,
+@@ -355,6 +357,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get selectablePlans() {
++    return null; // no plans to select in Vaultwarden
+     const selectedProductTierType = this.formGroup.controls.productTier.value;
+     const result =
+       this.passwordManagerPlans?.filter(
+@@ -485,6 +488,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get planOffersSecretsManager() {
++    return false; // no support for secrets manager in Vaultwarden
+     return this.selectedSecretsManagerPlan != null;
+   }
+ 
+@@ -493,6 +497,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   changedProduct() {
++    return; // no choice of products in Vaultwarden
+     const selectedPlan = this.selectablePlans[0];
+ 
+     this.setPlanType(selectedPlan.type);
+@@ -621,9 +626,8 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+         const collectionCt = collection.encryptedString;
+         const orgKeys = await this.keyService.makeKeyPair(orgKey[1]);
+ 
+-        orgId = this.selfHosted
+-          ? await this.createSelfHosted(key, collectionCt, orgKeys)
+-          : await this.createCloudHosted(key, collectionCt, orgKeys, orgKey[1]);
++        // always use createCloudHosted() to disable license file upload
++        orgId = await this.createCloudHosted(key, collectionCt, orgKeys, orgKey[1]);
+ 
+         this.toastService.showToast({
+           variant: "success",
+@@ -771,7 +775,9 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+     request.billingEmail = this.formGroup.controls.billingEmail.value;
+     request.initiationPath = "New organization creation in-product";
+     request.keys = new OrganizationKeysRequest(orgKeys[0], orgKeys[1].encryptedString);
++    request.planType = PlanType.Free; // always select the free plan in Vaultwarden
+ 
++    /* there is no plan to select in Vaultwarden
+     if (this.selectedPlan.type === PlanType.Free) {
+       request.planType = PlanType.Free;
+     } else {
+@@ -796,6 +802,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+ 
+     // Secrets Manager
+     this.buildSecretsManagerRequest(request);
++    end plan selection and no support for secret manager in Vaultwarden */
+ 
+     if (this.hasProvider) {
+       const providerRequest = new ProviderOrganizationCreateRequest(
+@@ -857,6 +864,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   private buildSecretsManagerRequest(
+     request: OrganizationCreateRequest | OrganizationUpgradeRequest,
+   ): void {
++    return; // Vaultwarden does not support SecretsManager
+     const formValues = this.secretsManagerForm.value;
+ 
+     request.useSecretsManager = this.planOffersSecretsManager && formValues.enabled;
+@@ -875,6 +883,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   private upgradeFlowPrefillForm() {
++    return; // Vaultwarden only supports free plan
+     if (this.acceptingSponsorship) {
+       this.formGroup.controls.productTier.setValue(ProductTierType.Families);
+       this.changedProduct();
+diff --git a/apps/web/src/app/core/router.service.ts b/apps/web/src/app/core/router.service.ts
+index ff0aea47b9..21ec31a19a 100644
+--- a/apps/web/src/app/core/router.service.ts
++++ b/apps/web/src/app/core/router.service.ts
+@@ -61,7 +61,7 @@ export class RouterService {
+       .subscribe((event: NavigationEnd) => {
+         this.currentUrl = event.url;
+ 
+-        let title = i18nService.t("bitWebVault");
++        let title = "Vaultwarden Web";
+ 
+         if (this.currentUrl.includes("/sm/")) {
+           title = i18nService.t("bitSecretsManager");
+diff --git a/apps/web/src/app/core/web-platform-utils.service.ts b/apps/web/src/app/core/web-platform-utils.service.ts
+index 3df2a7d895..f73d811690 100644
+--- a/apps/web/src/app/core/web-platform-utils.service.ts
++++ b/apps/web/src/app/core/web-platform-utils.service.ts
+@@ -135,14 +135,17 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
+   }
+ 
+   isDev(): boolean {
++    return false; // treat Vaultwarden as production ready
+     return process.env.NODE_ENV === "development";
+   }
+ 
+   isSelfHost(): boolean {
++    return true; // treat Vaultwarden as self hosted
+     return WebPlatformUtilsService.isSelfHost();
+   }
+ 
+   static isSelfHost(): boolean {
++    return true; // treat Vaultwarden as self hosted
+     return process.env.ENV.toString() === "selfhosted";
+   }
+ 
+diff --git a/apps/web/src/app/layouts/frontend-layout.component.html b/apps/web/src/app/layouts/frontend-layout.component.html
+index d19af54f5d..03c8edf631 100644
+--- a/apps/web/src/app/layouts/frontend-layout.component.html
++++ b/apps/web/src/app/layouts/frontend-layout.component.html
+@@ -3,6 +3,12 @@
+ <footer class="tw-text-center tw-my-12">
+   <environment-selector></environment-selector>
+ 
+-  <div bitTypography="body2">&copy; {{ year }} Bitwarden Inc.</div>
++  <div bitTypography="body2">Vaultwarden Web</div>
+   <div bitTypography="body2">{{ version }}</div>
++  <br />
++  <div bitTypography="helper" id="vw-disclaimer">
++    A modified version of the Bitwarden&reg; Web Vault for Vaultwarden (an unofficial rewrite of the
++    Bitwarden&reg; server).<br />
++    Vaultwarden is not associated with the Bitwarden&reg; project nor Bitwarden Inc.
++  </div>
+ </footer>
+diff --git a/apps/web/src/app/layouts/header/web-header.component.html b/apps/web/src/app/layouts/header/web-header.component.html
+index 28d786f2d6..652dcf241c 100644
+--- a/apps/web/src/app/layouts/header/web-header.component.html
++++ b/apps/web/src/app/layouts/header/web-header.component.html
+@@ -63,7 +63,12 @@
+                 <i class="bwi bwi-fw bwi-user" aria-hidden="true"></i>
+                 {{ "accountSettings" | i18n }}
+               </a>
+-              <a bitMenuItem href="https://bitwarden.com/help/" target="_blank" rel="noreferrer">
++              <a
++                bitMenuItem
++                href="https://github.com/dani-garcia/vaultwarden"
++                target="_blank"
++                rel="noreferrer"
++              >
+                 <i class="bwi bwi-fw bwi-question-circle" aria-hidden="true"></i>
+                 {{ "getHelp" | i18n }}
+               </a>
+diff --git a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
+index 08195d95bf..f51a216a14 100644
+--- a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
++++ b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
+@@ -10,10 +10,7 @@
+   >
+   </bit-nav-item>
+   <ng-container *ngIf="moreProducts$ | async as moreProducts">
+-    <section
+-      *ngIf="moreProducts.length > 0"
+-      class="tw-mt-2 tw-flex tw-w-full tw-flex-col tw-gap-2 tw-border-0"
+-    >
++    <section *ngIf="false" class="tw-mt-2 tw-flex tw-w-full tw-flex-col tw-gap-2 tw-border-0">
+       <span class="tw-text-xs !tw-text-alt2 tw-p-2 tw-pb-0">{{ "moreFromBitwarden" | i18n }}</span>
+       <ng-container *ngFor="let more of moreProducts">
+         <!-- <a> for when the marketing route is external -->
+diff --git a/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html b/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
+index 204737eee2..9bee4f6e03 100644
+--- a/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
++++ b/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
+@@ -30,7 +30,7 @@
+ 
+     <!-- Other options -->
+     <section
+-      *ngIf="products.other.length > 0"
++      *ngIf="false"
+       class="tw-mt-4 tw-flex tw-w-full tw-flex-col tw-gap-2 tw-border-0 tw-border-t tw-border-solid tw-border-t-text-muted tw-p-2 tw-pb-0"
+     >
+       <span class="tw-mb-1 tw-text-xs tw-text-muted">{{ "moreFromBitwarden" | i18n }}</span>
+diff --git a/apps/web/src/app/layouts/user-layout.component.ts b/apps/web/src/app/layouts/user-layout.component.ts
+index e859993af3..125b53fdf1 100644
+--- a/apps/web/src/app/layouts/user-layout.component.ts
++++ b/apps/web/src/app/layouts/user-layout.component.ts
+@@ -3,7 +3,7 @@
+ import { CommonModule } from "@angular/common";
+ import { Component, OnInit } from "@angular/core";
+ import { RouterModule } from "@angular/router";
+-import { Observable, switchMap } from "rxjs";
++import { Observable, of } from "rxjs";
+ 
+ import { JslibModule } from "@bitwarden/angular/jslib.module";
+ import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+@@ -40,15 +40,14 @@ export class UserLayoutComponent implements OnInit {
+     private billingAccountProfileStateService: BillingAccountProfileStateService,
+     private accountService: AccountService,
+   ) {
+-    this.showSubscription$ = this.accountService.activeAccount$.pipe(
+-      switchMap((account) =>
+-        this.billingAccountProfileStateService.canViewSubscription$(account.id),
+-      ),
+-    );
++    this.showSubscription$ = of(false); // always hide subscriptions in Vaultwarden
+   }
+ 
+   async ngOnInit() {
+     document.body.classList.remove("layout_frontend");
+     await this.syncService.fullSync(false);
++
++    this.hasFamilySponsorshipAvailable$ = of(false); // disable family Sponsorships in Vaultwarden
++    this.showSponsoredFamilies$ = of(false); // disable family Sponsorships in Vaultwarden
+   }
+ }
+diff --git a/apps/web/src/app/platform/web-environment.service.ts b/apps/web/src/app/platform/web-environment.service.ts
+index 1df842d6b3..d61637c92e 100644
+--- a/apps/web/src/app/platform/web-environment.service.ts
++++ b/apps/web/src/app/platform/web-environment.service.ts
+@@ -38,7 +38,17 @@ export class WebEnvironmentService extends DefaultEnvironmentService {
+     super(stateProvider, accountService, additionalRegionConfigs);
+ 
+     // The web vault always uses the current location as the base url
+-    envUrls.base ??= this.win.location.origin;
++    // If the base URL is `https://vaultwarden.example.com/base/path/`,
++    // `window.location.href` should have one of the following forms:
++    //
++    // - `https://vaultwarden.example.com/base/path/`
++    // - `https://vaultwarden.example.com/base/path/#/some/route[?queryParam=...]`
++    // - `https://vaultwarden.example.com/base/path/?queryParam=...`
++    //
++    // We want to get to just `https://vaultwarden.example.com/base/path`.
++    let baseUrl = this.win.location.href;
++    baseUrl = baseUrl.replace(/(\/+|\/*#.*|\/*\?.*)$/, ""); // Strip off trailing `/`, `#`, `?` and everything after.
++    envUrls.base ??= baseUrl;
+ 
+     // Find the region
+     const currentHostname = new URL(this.win.location.href).hostname;
+diff --git a/apps/web/src/app/tools/send/add-edit.component.html b/apps/web/src/app/tools/send/add-edit.component.html
+index 7eade18a7c..b8f865faa7 100644
+--- a/apps/web/src/app/tools/send/add-edit.component.html
++++ b/apps/web/src/app/tools/send/add-edit.component.html
+@@ -230,7 +230,12 @@
+             <bit-label for="password" *ngIf="!hasPassword">{{ "password" | i18n }}</bit-label>
+             <bit-label for="password" *ngIf="hasPassword">{{ "newPassword" | i18n }}</bit-label>
+ 
+-            <input bitInput type="password" formControlName="password" />
++            <input
++              bitInput
++              type="password"
++              formControlName="password"
++              autocomplete="new-password"
++            />
+             <button type="button" bitIconButton bitSuffix bitPasswordInputToggle></button>
+             <bit-hint>{{ "sendPasswordDesc" | i18n }}</bit-hint>
+           </bit-form-field>
+diff --git a/apps/web/src/app/tools/send/send-access/send-access-explainer.component.html b/apps/web/src/app/tools/send/send-access/send-access-explainer.component.html
+index f56b68cc29..284b916514 100644
+--- a/apps/web/src/app/tools/send/send-access/send-access-explainer.component.html
++++ b/apps/web/src/app/tools/send/send-access/send-access-explainer.component.html
+@@ -1,18 +1,5 @@
+ <div class="tw-text-center tw-text-muted">
+   <p bitTypography="body2" class="tw-mb-0">
+     {{ "sendAccessTaglineProductDesc" | i18n }}
+-    {{ "sendAccessTaglineLearnMore" | i18n }}
+-    <a
+-      bitLink
+-      href="https://www.bitwarden.com/products/send?source=web-vault"
+-      target="_blank"
+-      rel="noreferrer"
+-      >Bitwarden Send</a
+-    >
+-    {{ "sendAccessTaglineOr" | i18n }}
+-    <a bitLink routerLink="/signup" target="_blank" rel="noreferrer">{{
+-      "sendAccessTaglineSignUp" | i18n
+-    }}</a>
+-    {{ "sendAccessTaglineTryToday" | i18n }}
+   </p>
+ </div>
+diff --git a/apps/web/src/index.html b/apps/web/src/index.html
+index 0b8ea86491..5d98411f46 100644
+--- a/apps/web/src/index.html
++++ b/apps/web/src/index.html
+@@ -5,19 +5,21 @@
+     <meta name="viewport" content="width=1010" />
+     <meta name="theme-color" content="#175DDC" />
+ 
+-    <title page-title>Bitwarden Web vault</title>
++    <title page-title>Vaultwarden Web</title>
+ 
+     <link rel="apple-touch-icon" sizes="180x180" href="images/icons/apple-touch-icon.png" />
+     <link rel="icon" type="image/png" sizes="32x32" href="images/icons/favicon-32x32.png" />
+     <link rel="icon" type="image/png" sizes="16x16" href="images/icons/favicon-16x16.png" />
+     <link rel="mask-icon" href="images/icons/safari-pinned-tab.svg" color="#175DDC" />
+     <link rel="manifest" href="manifest.json" />
++    <!-- webpackIgnore: true -->
++    <link rel="stylesheet" href="css/vaultwarden.css" />
+   </head>
+   <body class="layout_frontend">
+     <app-root>
+       <!-- Note: any changes to this html need to be made in the app.component.html as well -->
+       <div class="tw-p-8 tw-flex">
+-        <img class="new-logo-themed" alt="Bitwarden" />
++        <img class="new-logo-themed" alt="Vaultwarden" />
+         <div class="spinner-container tw-justify-center">
+           <i
+             class="bwi bwi-spinner bwi-spin bwi-3x tw-text-muted"
+diff --git a/apps/web/src/manifest.json b/apps/web/src/manifest.json
+index 92a1204c60..d9ff4771a3 100644
+--- a/apps/web/src/manifest.json
++++ b/apps/web/src/manifest.json
+@@ -1,5 +1,5 @@
+ {
+-  "name": "Bitwarden Vault",
++  "name": "Vaultwarden Web",
+   "icons": [
+     {
+       "src": "images/icons/android-chrome-192x192.png",
+@@ -12,6 +12,6 @@
+       "type": "image/png"
+     }
+   ],
+-  "theme_color": "#175DDC",
+-  "background_color": "#175DDC"
++  "theme_color": "#FFFFFF",
++  "background_color": "#FFFFFF"
+ }
+diff --git a/apps/web/src/scss/tailwind.css b/apps/web/src/scss/tailwind.css
+index 0ae3c291b5..3a28c7868c 100644
+--- a/apps/web/src/scss/tailwind.css
++++ b/apps/web/src/scss/tailwind.css
+@@ -51,7 +51,7 @@
+   img.new-logo-themed {
+     @apply tw-block;
+ 
+-    width: 128px;
++    width: 175px;
+   }
+   .theme_light img.new-logo-themed {
+     content: url("../images/logo.svg");
+diff --git a/apps/web/tailwind.config.js b/apps/web/tailwind.config.js
+index 4a3f6cfef1..8b1d6081a6 100644
+--- a/apps/web/tailwind.config.js
++++ b/apps/web/tailwind.config.js
+@@ -8,7 +8,6 @@ config.content = [
+   "../../libs/key-management-ui/src/**/*.{html,ts}",
+   "../../libs/vault/src/**/*.{html,ts}",
+   "../../libs/angular/src/**/*.{html,ts}",
+-  "../../bitwarden_license/bit-web/src/**/*.{html,ts}",
+ ];
+ 
+ module.exports = config;
+diff --git a/apps/web/tsconfig.json b/apps/web/tsconfig.json
+index d1da8ac453..b67980180c 100644
+--- a/apps/web/tsconfig.json
++++ b/apps/web/tsconfig.json
+@@ -10,7 +10,6 @@
+       "@bitwarden/auth/angular": ["../../libs/auth/src/angular"],
+       "@bitwarden/auth/common": ["../../libs/auth/src/common"],
+       "@bitwarden/billing": ["../../libs/billing/src"],
+-      "@bitwarden/bit-common/*": ["../../bitwarden_license/bit-common/src/*"],
+       "@bitwarden/common/*": ["../../libs/common/src/*"],
+       "@bitwarden/components": ["../../libs/components/src"],
+       "@bitwarden/generator-components": ["../../libs/tools/generator/components/src"],
+diff --git a/clients.code-workspace b/clients.code-workspace
+index f7d86d2a24..75389727d2 100644
+--- a/clients.code-workspace
++++ b/clients.code-workspace
+@@ -8,18 +8,10 @@
+       "name": "web vault",
+       "path": "apps/web",
+     },
+-    {
+-      "name": "web vault (bit)",
+-      "path": "bitwarden_license/bit-web",
+-    },
+     {
+       "name": "cli",
+       "path": "apps/cli",
+     },
+-    {
+-      "name": "cli (bit)",
+-      "path": "bitwarden_license/bit-cli",
+-    },
+     {
+       "name": "desktop",
+       "path": "apps/desktop",
+@@ -32,10 +24,6 @@
+       "name": "libs",
+       "path": "libs",
+     },
+-    {
+-      "name": "common (bit)",
+-      "path": "bitwarden_license/bit-common",
+-    },
+   ],
+   "settings": {
+     "eslint.options": {
+diff --git a/jest.config.js b/jest.config.js
+index e8815f92ff..c635c2fc45 100644
+--- a/jest.config.js
++++ b/jest.config.js
+@@ -20,9 +20,6 @@ module.exports = {
+     "<rootDir>/apps/cli/jest.config.js",
+     "<rootDir>/apps/desktop/jest.config.js",
+     "<rootDir>/apps/web/jest.config.js",
+-    "<rootDir>/bitwarden_license/bit-web/jest.config.js",
+-    "<rootDir>/bitwarden_license/bit-cli/jest.config.js",
+-    "<rootDir>/bitwarden_license/bit-common/jest.config.js",
+ 
+     "<rootDir>/libs/admin-console/jest.config.js",
+     "<rootDir>/libs/angular/jest.config.js",
+diff --git a/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts b/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
+index 04dc3b6dfd..2791b0bc17 100644
+--- a/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
++++ b/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
+@@ -8,6 +8,8 @@ import { AnonLayoutComponent } from "@bitwarden/auth/angular";
+ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+ import { Icon, Translation } from "@bitwarden/components";
+ 
++import { BitwardenShield } from "../icons";
++
+ import { AnonLayoutWrapperDataService } from "./anon-layout-wrapper-data.service";
+ 
+ export interface AnonLayoutWrapperData {
+@@ -160,7 +162,7 @@ export class AnonLayoutWrapperComponent implements OnInit, OnDestroy {
+   private resetPageData() {
+     this.pageTitle = null;
+     this.pageSubtitle = null;
+-    this.pageIcon = null;
++    this.pageIcon = BitwardenShield;
+     this.showReadonlyHostname = null;
+     this.maxWidth = null;
+     this.titleAreaMaxWidth = null;
+diff --git a/libs/auth/src/angular/anon-layout/anon-layout.component.html b/libs/auth/src/angular/anon-layout/anon-layout.component.html
+index 4120ea5900..1adea588fd 100644
+--- a/libs/auth/src/angular/anon-layout/anon-layout.component.html
++++ b/libs/auth/src/angular/anon-layout/anon-layout.component.html
+@@ -8,7 +8,7 @@
+   <a
+     *ngIf="!hideLogo"
+     [routerLink]="['/']"
+-    class="tw-w-[128px] tw-block tw-mb-12 [&>*]:tw-align-top"
++    class="tw-w-[175px] tw-block tw-mb-12 [&>*]:tw-align-top"
+   >
+     <bit-icon [icon]="logo"></bit-icon>
+   </a>
+@@ -55,8 +55,14 @@
+       <ng-content select="[slot=environment-selector]"></ng-content>
+     </ng-container>
+     <ng-container *ngIf="!hideYearAndVersion">
+-      <div bitTypography="body2">&copy; {{ year }} Bitwarden Inc.</div>
++      <div bitTypography="body2">Vaultwarden Web</div>
+       <div bitTypography="body2">{{ version }}</div>
++      <br />
++      <div bitTypography="helper" id="vw-disclaimer">
++        A modified version of the Bitwarden&reg; Web Vault for Vaultwarden (an unofficial rewrite of
++        the Bitwarden&reg; server).<br />
++        Vaultwarden is not associated with the Bitwarden&reg; project nor Bitwarden Inc.
++      </div>
+     </ng-container>
+   </footer>
+ </main>
+diff --git a/libs/auth/src/angular/login/login-secondary-content.component.ts b/libs/auth/src/angular/login/login-secondary-content.component.ts
+index b608542b37..4f0b86baa7 100644
+--- a/libs/auth/src/angular/login/login-secondary-content.component.ts
++++ b/libs/auth/src/angular/login/login-secondary-content.component.ts
+@@ -11,7 +11,6 @@ import { LinkModule } from "@bitwarden/components";
+   imports: [CommonModule, JslibModule, LinkModule, RouterModule],
+   template: `
+     <div class="tw-text-center" *ngIf="!(isUserRegistrationDisabled$ | async)">
+-      {{ "newToBitwarden" | i18n }}
+       <a bitLink routerLink="/signup">{{ "createAccount" | i18n }}</a>
+     </div>
+   `,
+diff --git a/libs/auth/src/angular/registration/registration-start/registration-start.component.html b/libs/auth/src/angular/registration/registration-start/registration-start.component.html
+index de3611a597..23a7324566 100644
+--- a/libs/auth/src/angular/registration/registration-start/registration-start.component.html
++++ b/libs/auth/src/angular/registration/registration-start/registration-start.component.html
+@@ -53,7 +53,7 @@
+       {{ "continue" | i18n }}
+     </button>
+ 
+-    <p bitTypography="helper" class="tw-text-main tw-text-xs tw-mb-0">
++    <p bitTypography="helper" class="tw-text-main tw-text-xs tw-mb-0" *ngIf="!isSelfHost">
+       {{ "byContinuingYouAgreeToThe" | i18n }}
+       <a
+         bitLink
+diff --git a/libs/common/src/admin-console/models/domain/organization.ts b/libs/common/src/admin-console/models/domain/organization.ts
+index 6f7ff561f0..8e5da8470a 100644
+--- a/libs/common/src/admin-console/models/domain/organization.ts
++++ b/libs/common/src/admin-console/models/domain/organization.ts
+@@ -365,6 +365,7 @@ export class Organization {
+   }
+ 
+   get canAccessIntegrations() {
++    return false; // disable integrations for Vaultwarden
+     return (
+       (this.productTierType === ProductTierType.Teams ||
+         this.productTierType === ProductTierType.Enterprise) &&
+diff --git a/libs/components/src/tw-theme.css b/libs/components/src/tw-theme.css
+index 7d11366029..776993ff88 100644
+--- a/libs/components/src/tw-theme.css
++++ b/libs/components/src/tw-theme.css
+@@ -12,13 +12,13 @@
+   --color-background: 255 255 255;
+   --color-background-alt: 243 246 249;
+   --color-background-alt2: 23 92 219;
+-  --color-background-alt3: 26 65 172;
+-  --color-background-alt4: 2 15 102;
++  --color-background-alt3: 33 37 41; /* bg of menu panel */
++  --color-background-alt4: 16 18 21; /* bg of active menu item */
+ 
+   --color-primary-100: 219 229 246;
+-  --color-primary-300: 121 161 233;
+-  --color-primary-600: 23 93 220;
+-  --color-primary-700: 26 65 172;
++  --color-primary-300: 108 117 125; /* hover of menu items */
++  --color-primary-600: 18 82 163; /* color of links and buttons */
++  --color-primary-700: 13 60 119; /* hover of links and buttons */
+ 
+   --color-secondary-100: 230 233 239;
+   --color-secondary-300: 168 179 200;
+@@ -54,7 +54,7 @@
+   --color-text-alt2: 255 255 255;
+   --color-text-code: 192 17 118;
+ 
+-  --color-marketing-logo: 23 93 220;
++  --color-marketing-logo: 15 15 15; /* The Vaultwarden Logo */
+ 
+   --tw-ring-offset-color: #ffffff;
+ }
+diff --git a/libs/components/tailwind.config.js b/libs/components/tailwind.config.js
+index 2df648723f..be4e907625 100644
+--- a/libs/components/tailwind.config.js
++++ b/libs/components/tailwind.config.js
+@@ -7,7 +7,6 @@ config.content = [
+   "libs/vault/src/**/*.{html,ts,mdx}",
+   "apps/web/src/**/*.{html,ts,mdx}",
+   "apps/browser/src/**/*.{html,ts,mdx}",
+-  "bitwarden_license/bit-web/src/**/*.{html,ts,mdx}",
+   ".storybook/preview.tsx",
+ ];
+ config.safelist = [
+diff --git a/tailwind.config.js b/tailwind.config.js
+index 637c28a54e..7afcea4e65 100644
+--- a/tailwind.config.js
++++ b/tailwind.config.js
+@@ -10,7 +10,6 @@ config.content = [
+   "./libs/tools/send/send-ui/src/*.{html,ts,mdx}",
+   "./libs/vault/src/**/*.{html,ts,mdx}",
+   "./apps/web/src/**/*.{html,ts,mdx}",
+-  "./bitwarden_license/bit-web/src/**/*.{html,ts,mdx}",
+   "./.storybook/preview.js",
+ ];
+ config.safelist = [
+diff --git a/tsconfig.json b/tsconfig.json
+index cfc33f572e..b762aca91e 100644
+--- a/tsconfig.json
++++ b/tsconfig.json
+@@ -55,9 +55,7 @@
+     "apps/browser/src/**/*",
+     "libs/*/src/**/*",
+     "libs/tools/send/**/src/**/*",
+-    "libs/tools/card/src/**/*",
+-    "bitwarden_license/bit-web/src/**/*",
+-    "bitwarden_license/bit-common/src/**/*"
++    "libs/tools/card/src/**/*"
+   ],
+   "exclude": [
+     "apps/web/src/**/*.spec.ts",

--- a/patches/v2025.3.1.patch
+++ b/patches/v2025.3.1.patch
@@ -1,0 +1,784 @@
+diff --git a/apps/web/config/base.json b/apps/web/config/base.json
+index e64ef6ebeb..b41ca4219d 100644
+--- a/apps/web/config/base.json
++++ b/apps/web/config/base.json
+@@ -1,11 +1,5 @@
+ {
+   "urls": {},
+-  "stripeKey": "pk_test_KPoCfZXu7mznb9uSCPZ2JpTD",
+-  "braintreeKey": "sandbox_r72q8jq6_9pnxkwm75f87sdc2",
+-  "paypal": {
+-    "businessId": "AD3LAUZSNVPJY",
+-    "buttonAction": "https://www.sandbox.paypal.com/cgi-bin/webscr"
+-  },
+   "dev": {
+     "port": 8080,
+     "allowedHosts": "auto"
+diff --git a/apps/web/src/app/admin-console/organizations/create/organization-information.component.html b/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
+index e0a8006081..789efd9264 100644
+--- a/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
++++ b/apps/web/src/app/admin-console/organizations/create/organization-information.component.html
+@@ -12,7 +12,7 @@
+       <input bitInput type="text" formControlName="name" />
+     </bit-form-field>
+     <bit-form-field class="tw-w-1/2">
+-      <bit-label>{{ "billingEmail" | i18n }}</bit-label>
++      <bit-label>{{ "email" | i18n }}</bit-label>
+       <input bitInput type="email" formControlName="billingEmail" />
+     </bit-form-field>
+     <bit-form-field class="tw-w-1/2" *ngIf="isProvider">
+diff --git a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
+index 0f3ca55da6..4afd35882c 100644
+--- a/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
++++ b/apps/web/src/app/admin-console/organizations/layouts/organization-layout.component.ts
+@@ -163,6 +163,7 @@ export class OrganizationLayoutComponent implements OnInit {
+   }
+ 
+   canShowBillingTab(organization: Organization): boolean {
++    return false; // disable billing tab in Vaultwarden
+     return canAccessBillingTab(organization);
+   }
+ 
+diff --git a/apps/web/src/app/admin-console/organizations/members/members.component.ts b/apps/web/src/app/admin-console/organizations/members/members.component.ts
+index 0bfdde8fc9..2c4132230f 100644
+--- a/apps/web/src/app/admin-console/organizations/members/members.component.ts
++++ b/apps/web/src/app/admin-console/organizations/members/members.component.ts
+@@ -211,11 +211,7 @@ export class MembersComponent extends BaseMembersComponent<OrganizationUserView>
+             .find((p) => p.organizationId === this.organization.id);
+           this.orgResetPasswordPolicyEnabled = resetPasswordPolicy?.enabled;
+ 
+-          const billingMetadata = await this.billingApiService.getOrganizationBillingMetadata(
+-            this.organization.id,
+-          );
+-
+-          this.orgIsOnSecretsManagerStandalone = billingMetadata.isOnSecretsManagerStandalone;
++          this.orgIsOnSecretsManagerStandalone = false; // don't get billing metadata
+ 
+           await this.load();
+ 
+diff --git a/apps/web/src/app/admin-console/organizations/settings/account.component.html b/apps/web/src/app/admin-console/organizations/settings/account.component.html
+index ae1ecb6f3b..5cbb2d0d84 100644
+--- a/apps/web/src/app/admin-console/organizations/settings/account.component.html
++++ b/apps/web/src/app/admin-console/organizations/settings/account.component.html
+@@ -16,7 +16,7 @@
+           <input bitInput id="orgName" type="text" formControlName="orgName" />
+         </bit-form-field>
+         <bit-form-field>
+-          <bit-label>{{ "billingEmail" | i18n }}</bit-label>
++          <bit-label>{{ "email" | i18n }}</bit-label>
+           <input bitInput id="billingEmail" formControlName="billingEmail" type="email" />
+         </bit-form-field>
+       </div>
+diff --git a/apps/web/src/app/admin-console/organizations/settings/account.component.ts b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+index 57892442c1..299b336d3f 100644
+--- a/apps/web/src/app/admin-console/organizations/settings/account.component.ts
++++ b/apps/web/src/app/admin-console/organizations/settings/account.component.ts
+@@ -103,7 +103,7 @@ export class AccountComponent implements OnInit, OnDestroy {
+   ) {}
+ 
+   async ngOnInit() {
+-    this.selfHosted = this.platformUtilsService.isSelfHost();
++    this.selfHosted = false; // set to false so we can rename organizations
+ 
+     this.configService
+       .getFeatureFlag$(FeatureFlag.LimitItemDeletion)
+diff --git a/apps/web/src/app/app.component.html b/apps/web/src/app/app.component.html
+index 471d89be1c..110a55538b 100644
+--- a/apps/web/src/app/app.component.html
++++ b/apps/web/src/app/app.component.html
+@@ -3,7 +3,7 @@
+    when the body has the layout_frontend class. Having this match the index allows for a duplicative yet seamless
+    loading state here for process reloading. -->
+   <div class="tw-p-8 tw-flex">
+-    <img class="new-logo-themed" alt="Bitwarden" />
++    <img class="new-logo-themed" alt="Vaultwarden" />
+     <div class="spinner-container tw-justify-center">
+       <i
+         class="bwi bwi-spinner bwi-spin bwi-3x tw-text-muted"
+diff --git a/apps/web/src/app/app.component.ts b/apps/web/src/app/app.component.ts
+index 55e2595e0f..b3d4e1530d 100644
+--- a/apps/web/src/app/app.component.ts
++++ b/apps/web/src/app/app.component.ts
+@@ -197,6 +197,10 @@ export class AppComponent implements OnDestroy, OnInit {
+             break;
+           }
+           case "showToast":
++            if (typeof message.text === "string" && typeof crypto.subtle === "undefined") {
++              message.title = "This browser requires HTTPS to use the web vault";
++              message.text = "Check the Vaultwarden wiki for details on how to enable it";
++            }
+             this.toastService._showToast(message);
+             break;
+           case "convertAccountToKeyConnector":
+diff --git a/apps/web/src/app/auth/settings/change-password.component.html b/apps/web/src/app/auth/settings/change-password.component.html
+index 91144fdfc1..d3dc4410c9 100644
+--- a/apps/web/src/app/auth/settings/change-password.component.html
++++ b/apps/web/src/app/auth/settings/change-password.component.html
+@@ -125,5 +125,3 @@
+     {{ "changeMasterPassword" | i18n }}
+   </button>
+ </form>
+-
+-<app-webauthn-login-settings></app-webauthn-login-settings>
+diff --git a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
+index de187d2c33..c33f49fd70 100644
+--- a/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
++++ b/apps/web/src/app/auth/settings/two-factor/two-factor-setup-authenticator.component.ts
+@@ -189,11 +189,11 @@ export class TwoFactorSetupAuthenticatorComponent
+     new window.QRious({
+       element: document.getElementById("qr"),
+       value:
+-        "otpauth://totp/Bitwarden:" +
++        "otpauth://totp/Vaultwarden:" +
+         Utils.encodeRFC3986URIComponent(email) +
+         "?secret=" +
+         encodeURIComponent(this.key) +
+-        "&issuer=Bitwarden",
++        "&issuer=Vaultwarden",
+       size: 160,
+     });
+   }
+diff --git a/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts b/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
+index d533badabf..6512ecbd13 100644
+--- a/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
++++ b/apps/web/src/app/billing/organizations/organization-billing-history-view.component.ts
+@@ -54,6 +54,7 @@ export class OrgBillingHistoryViewComponent implements OnInit, OnDestroy {
+ 
+     this.loading = true;
+ 
++    /* disable billing history
+     const openInvoicesPromise = this.organizationBillingApiService.getBillingInvoices(
+       this.organizationId,
+       "open",
+@@ -87,6 +88,7 @@ export class OrgBillingHistoryViewComponent implements OnInit, OnDestroy {
+       openInvoices.length <= pageSize ||
+       paidInvoices.length <= pageSize ||
+       transactions.length <= pageSize;
++    */
+ 
+     this.loading = false;
+   }
+diff --git a/apps/web/src/app/billing/organizations/organization-plans.component.html b/apps/web/src/app/billing/organizations/organization-plans.component.html
+index 3b765927c3..393e3bc108 100644
+--- a/apps/web/src/app/billing/organizations/organization-plans.component.html
++++ b/apps/web/src/app/billing/organizations/organization-plans.component.html
+@@ -6,17 +6,12 @@
+   ></i>
+   <span class="tw-sr-only">{{ "loading" | i18n }}</span>
+ </ng-container>
+-<ng-container *ngIf="createOrganization && selfHosted">
++<ng-container *ngIf="createOrganization && false">
+   <organization-self-hosting-license-uploader
+     (onLicenseFileUploaded)="onLicenseFileUploaded($event)"
+   />
+ </ng-container>
+-<form
+-  [formGroup]="formGroup"
+-  [bitSubmit]="submit"
+-  *ngIf="!loading && !selfHosted && this.passwordManagerPlans && this.secretsManagerPlans"
+-  class="tw-pt-6"
+->
++<form [formGroup]="formGroup" [bitSubmit]="submit" *ngIf="!loading" class="tw-pt-6">
+   <bit-section [ngClass]="{ 'tw-hidden': !createOrganization }">
+     <app-org-info
+       (changedBusinessOwned)="changedOwnedBusiness()"
+diff --git a/apps/web/src/app/billing/organizations/organization-plans.component.ts b/apps/web/src/app/billing/organizations/organization-plans.component.ts
+index 84f2467b1b..e7a4ad1687 100644
+--- a/apps/web/src/app/billing/organizations/organization-plans.component.ts
++++ b/apps/web/src/app/billing/organizations/organization-plans.component.ts
+@@ -190,13 +190,12 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+           .organizations$(userId)
+           .pipe(getOrganizationById(this.organizationId)),
+       );
+-      this.billing = await this.organizationApiService.getBilling(this.organizationId);
+-      this.sub = await this.organizationApiService.getSubscription(this.organizationId);
+-      this.taxInformation = await this.organizationApiService.getTaxInfo(this.organizationId);
+-    } else if (!this.selfHosted) {
+-      this.taxInformation = await this.apiService.getTaxInfo();
++      this.billing = null; // no billing in Vaultwarden
++      this.sub = null; // no subscriptions in Vaultwarden;
++      this.taxInformation = null; // no taxes in Vaultwarden;
+     }
+ 
++    /* no need to ask /api/plans because Vaultwarden only supports the free plan
+     if (!this.selfHosted) {
+       const plans = await this.apiService.getPlans();
+       this.passwordManagerPlans = plans.data.filter((plan) => !!plan.PasswordManager);
+@@ -232,6 +231,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+       this.plan = providerDefaultPlan.type;
+       this.productTier = providerDefaultPlan.productTier;
+     }
++    end of asking /api/plans in Vaultwarden */
+ 
+     if (!this.createOrganization) {
+       this.upgradeFlowPrefillForm();
+@@ -289,6 +289,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get upgradeRequiresPaymentMethod() {
++    return false; // Vaultwarden is always free
+     return (
+       this.organization?.productTierType === ProductTierType.Free &&
+       !this.showFree &&
+@@ -324,6 +325,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get selectableProducts() {
++    return null; // there are no products to select in Vaultwarden
+     if (this.acceptingSponsorship) {
+       const familyPlan = this.passwordManagerPlans.find(
+         (plan) => plan.type === PlanType.FamiliesAnnually,
+@@ -355,6 +357,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get selectablePlans() {
++    return null; // no plans to select in Vaultwarden
+     const selectedProductTierType = this.formGroup.controls.productTier.value;
+     const result =
+       this.passwordManagerPlans?.filter(
+@@ -485,6 +488,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   get planOffersSecretsManager() {
++    return false; // no support for secrets manager in Vaultwarden
+     return this.selectedSecretsManagerPlan != null;
+   }
+ 
+@@ -493,6 +497,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   changedProduct() {
++    return; // no choice of products in Vaultwarden
+     const selectedPlan = this.selectablePlans[0];
+ 
+     this.setPlanType(selectedPlan.type);
+@@ -621,9 +626,8 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+         const collectionCt = collection.encryptedString;
+         const orgKeys = await this.keyService.makeKeyPair(orgKey[1]);
+ 
+-        orgId = this.selfHosted
+-          ? await this.createSelfHosted(key, collectionCt, orgKeys)
+-          : await this.createCloudHosted(key, collectionCt, orgKeys, orgKey[1]);
++        // always use createCloudHosted() to disable license file upload
++        orgId = await this.createCloudHosted(key, collectionCt, orgKeys, orgKey[1]);
+ 
+         this.toastService.showToast({
+           variant: "success",
+@@ -771,7 +775,9 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+     request.billingEmail = this.formGroup.controls.billingEmail.value;
+     request.initiationPath = "New organization creation in-product";
+     request.keys = new OrganizationKeysRequest(orgKeys[0], orgKeys[1].encryptedString);
++    request.planType = PlanType.Free; // always select the free plan in Vaultwarden
+ 
++    /* there is no plan to select in Vaultwarden
+     if (this.selectedPlan.type === PlanType.Free) {
+       request.planType = PlanType.Free;
+     } else {
+@@ -796,6 +802,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+ 
+     // Secrets Manager
+     this.buildSecretsManagerRequest(request);
++    end plan selection and no support for secret manager in Vaultwarden */
+ 
+     if (this.hasProvider) {
+       const providerRequest = new ProviderOrganizationCreateRequest(
+@@ -857,6 +864,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   private buildSecretsManagerRequest(
+     request: OrganizationCreateRequest | OrganizationUpgradeRequest,
+   ): void {
++    return; // Vaultwarden does not support SecretsManager
+     const formValues = this.secretsManagerForm.value;
+ 
+     request.useSecretsManager = this.planOffersSecretsManager && formValues.enabled;
+@@ -875,6 +883,7 @@ export class OrganizationPlansComponent implements OnInit, OnDestroy {
+   }
+ 
+   private upgradeFlowPrefillForm() {
++    return; // Vaultwarden only supports free plan
+     if (this.acceptingSponsorship) {
+       this.formGroup.controls.productTier.setValue(ProductTierType.Families);
+       this.changedProduct();
+diff --git a/apps/web/src/app/core/router.service.ts b/apps/web/src/app/core/router.service.ts
+index ff0aea47b9..21ec31a19a 100644
+--- a/apps/web/src/app/core/router.service.ts
++++ b/apps/web/src/app/core/router.service.ts
+@@ -61,7 +61,7 @@ export class RouterService {
+       .subscribe((event: NavigationEnd) => {
+         this.currentUrl = event.url;
+ 
+-        let title = i18nService.t("bitWebVault");
++        let title = "Vaultwarden Web";
+ 
+         if (this.currentUrl.includes("/sm/")) {
+           title = i18nService.t("bitSecretsManager");
+diff --git a/apps/web/src/app/core/web-platform-utils.service.ts b/apps/web/src/app/core/web-platform-utils.service.ts
+index 3df2a7d895..f73d811690 100644
+--- a/apps/web/src/app/core/web-platform-utils.service.ts
++++ b/apps/web/src/app/core/web-platform-utils.service.ts
+@@ -135,14 +135,17 @@ export class WebPlatformUtilsService implements PlatformUtilsService {
+   }
+ 
+   isDev(): boolean {
++    return false; // treat Vaultwarden as production ready
+     return process.env.NODE_ENV === "development";
+   }
+ 
+   isSelfHost(): boolean {
++    return true; // treat Vaultwarden as self hosted
+     return WebPlatformUtilsService.isSelfHost();
+   }
+ 
+   static isSelfHost(): boolean {
++    return true; // treat Vaultwarden as self hosted
+     return process.env.ENV.toString() === "selfhosted";
+   }
+ 
+diff --git a/apps/web/src/app/layouts/frontend-layout.component.html b/apps/web/src/app/layouts/frontend-layout.component.html
+index d19af54f5d..03c8edf631 100644
+--- a/apps/web/src/app/layouts/frontend-layout.component.html
++++ b/apps/web/src/app/layouts/frontend-layout.component.html
+@@ -3,6 +3,12 @@
+ <footer class="tw-text-center tw-my-12">
+   <environment-selector></environment-selector>
+ 
+-  <div bitTypography="body2">&copy; {{ year }} Bitwarden Inc.</div>
++  <div bitTypography="body2">Vaultwarden Web</div>
+   <div bitTypography="body2">{{ version }}</div>
++  <br />
++  <div bitTypography="helper" id="vw-disclaimer">
++    A modified version of the Bitwarden&reg; Web Vault for Vaultwarden (an unofficial rewrite of the
++    Bitwarden&reg; server).<br />
++    Vaultwarden is not associated with the Bitwarden&reg; project nor Bitwarden Inc.
++  </div>
+ </footer>
+diff --git a/apps/web/src/app/layouts/header/web-header.component.html b/apps/web/src/app/layouts/header/web-header.component.html
+index 28d786f2d6..652dcf241c 100644
+--- a/apps/web/src/app/layouts/header/web-header.component.html
++++ b/apps/web/src/app/layouts/header/web-header.component.html
+@@ -63,7 +63,12 @@
+                 <i class="bwi bwi-fw bwi-user" aria-hidden="true"></i>
+                 {{ "accountSettings" | i18n }}
+               </a>
+-              <a bitMenuItem href="https://bitwarden.com/help/" target="_blank" rel="noreferrer">
++              <a
++                bitMenuItem
++                href="https://github.com/dani-garcia/vaultwarden"
++                target="_blank"
++                rel="noreferrer"
++              >
+                 <i class="bwi bwi-fw bwi-question-circle" aria-hidden="true"></i>
+                 {{ "getHelp" | i18n }}
+               </a>
+diff --git a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
+index 08195d95bf..f51a216a14 100644
+--- a/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
++++ b/apps/web/src/app/layouts/product-switcher/navigation-switcher/navigation-switcher.component.html
+@@ -10,10 +10,7 @@
+   >
+   </bit-nav-item>
+   <ng-container *ngIf="moreProducts$ | async as moreProducts">
+-    <section
+-      *ngIf="moreProducts.length > 0"
+-      class="tw-mt-2 tw-flex tw-w-full tw-flex-col tw-gap-2 tw-border-0"
+-    >
++    <section *ngIf="false" class="tw-mt-2 tw-flex tw-w-full tw-flex-col tw-gap-2 tw-border-0">
+       <span class="tw-text-xs !tw-text-alt2 tw-p-2 tw-pb-0">{{ "moreFromBitwarden" | i18n }}</span>
+       <ng-container *ngFor="let more of moreProducts">
+         <!-- <a> for when the marketing route is external -->
+diff --git a/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html b/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
+index 204737eee2..9bee4f6e03 100644
+--- a/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
++++ b/apps/web/src/app/layouts/product-switcher/product-switcher-content.component.html
+@@ -30,7 +30,7 @@
+ 
+     <!-- Other options -->
+     <section
+-      *ngIf="products.other.length > 0"
++      *ngIf="false"
+       class="tw-mt-4 tw-flex tw-w-full tw-flex-col tw-gap-2 tw-border-0 tw-border-t tw-border-solid tw-border-t-text-muted tw-p-2 tw-pb-0"
+     >
+       <span class="tw-mb-1 tw-text-xs tw-text-muted">{{ "moreFromBitwarden" | i18n }}</span>
+diff --git a/apps/web/src/app/layouts/user-layout.component.ts b/apps/web/src/app/layouts/user-layout.component.ts
+index e859993af3..125b53fdf1 100644
+--- a/apps/web/src/app/layouts/user-layout.component.ts
++++ b/apps/web/src/app/layouts/user-layout.component.ts
+@@ -3,7 +3,7 @@
+ import { CommonModule } from "@angular/common";
+ import { Component, OnInit } from "@angular/core";
+ import { RouterModule } from "@angular/router";
+-import { Observable, switchMap } from "rxjs";
++import { Observable, of } from "rxjs";
+ 
+ import { JslibModule } from "@bitwarden/angular/jslib.module";
+ import { AccountService } from "@bitwarden/common/auth/abstractions/account.service";
+@@ -40,15 +40,14 @@ export class UserLayoutComponent implements OnInit {
+     private billingAccountProfileStateService: BillingAccountProfileStateService,
+     private accountService: AccountService,
+   ) {
+-    this.showSubscription$ = this.accountService.activeAccount$.pipe(
+-      switchMap((account) =>
+-        this.billingAccountProfileStateService.canViewSubscription$(account.id),
+-      ),
+-    );
++    this.showSubscription$ = of(false); // always hide subscriptions in Vaultwarden
+   }
+ 
+   async ngOnInit() {
+     document.body.classList.remove("layout_frontend");
+     await this.syncService.fullSync(false);
++
++    this.hasFamilySponsorshipAvailable$ = of(false); // disable family Sponsorships in Vaultwarden
++    this.showSponsoredFamilies$ = of(false); // disable family Sponsorships in Vaultwarden
+   }
+ }
+diff --git a/apps/web/src/app/platform/web-environment.service.ts b/apps/web/src/app/platform/web-environment.service.ts
+index 1df842d6b3..d61637c92e 100644
+--- a/apps/web/src/app/platform/web-environment.service.ts
++++ b/apps/web/src/app/platform/web-environment.service.ts
+@@ -38,7 +38,17 @@ export class WebEnvironmentService extends DefaultEnvironmentService {
+     super(stateProvider, accountService, additionalRegionConfigs);
+ 
+     // The web vault always uses the current location as the base url
+-    envUrls.base ??= this.win.location.origin;
++    // If the base URL is `https://vaultwarden.example.com/base/path/`,
++    // `window.location.href` should have one of the following forms:
++    //
++    // - `https://vaultwarden.example.com/base/path/`
++    // - `https://vaultwarden.example.com/base/path/#/some/route[?queryParam=...]`
++    // - `https://vaultwarden.example.com/base/path/?queryParam=...`
++    //
++    // We want to get to just `https://vaultwarden.example.com/base/path`.
++    let baseUrl = this.win.location.href;
++    baseUrl = baseUrl.replace(/(\/+|\/*#.*|\/*\?.*)$/, ""); // Strip off trailing `/`, `#`, `?` and everything after.
++    envUrls.base ??= baseUrl;
+ 
+     // Find the region
+     const currentHostname = new URL(this.win.location.href).hostname;
+diff --git a/apps/web/src/app/tools/send/send-access/send-access-explainer.component.html b/apps/web/src/app/tools/send/send-access/send-access-explainer.component.html
+index f56b68cc29..284b916514 100644
+--- a/apps/web/src/app/tools/send/send-access/send-access-explainer.component.html
++++ b/apps/web/src/app/tools/send/send-access/send-access-explainer.component.html
+@@ -1,18 +1,5 @@
+ <div class="tw-text-center tw-text-muted">
+   <p bitTypography="body2" class="tw-mb-0">
+     {{ "sendAccessTaglineProductDesc" | i18n }}
+-    {{ "sendAccessTaglineLearnMore" | i18n }}
+-    <a
+-      bitLink
+-      href="https://www.bitwarden.com/products/send?source=web-vault"
+-      target="_blank"
+-      rel="noreferrer"
+-      >Bitwarden Send</a
+-    >
+-    {{ "sendAccessTaglineOr" | i18n }}
+-    <a bitLink routerLink="/signup" target="_blank" rel="noreferrer">{{
+-      "sendAccessTaglineSignUp" | i18n
+-    }}</a>
+-    {{ "sendAccessTaglineTryToday" | i18n }}
+   </p>
+ </div>
+diff --git a/apps/web/src/index.html b/apps/web/src/index.html
+index 0b8ea86491..5d98411f46 100644
+--- a/apps/web/src/index.html
++++ b/apps/web/src/index.html
+@@ -5,19 +5,21 @@
+     <meta name="viewport" content="width=1010" />
+     <meta name="theme-color" content="#175DDC" />
+ 
+-    <title page-title>Bitwarden Web vault</title>
++    <title page-title>Vaultwarden Web</title>
+ 
+     <link rel="apple-touch-icon" sizes="180x180" href="images/icons/apple-touch-icon.png" />
+     <link rel="icon" type="image/png" sizes="32x32" href="images/icons/favicon-32x32.png" />
+     <link rel="icon" type="image/png" sizes="16x16" href="images/icons/favicon-16x16.png" />
+     <link rel="mask-icon" href="images/icons/safari-pinned-tab.svg" color="#175DDC" />
+     <link rel="manifest" href="manifest.json" />
++    <!-- webpackIgnore: true -->
++    <link rel="stylesheet" href="css/vaultwarden.css" />
+   </head>
+   <body class="layout_frontend">
+     <app-root>
+       <!-- Note: any changes to this html need to be made in the app.component.html as well -->
+       <div class="tw-p-8 tw-flex">
+-        <img class="new-logo-themed" alt="Bitwarden" />
++        <img class="new-logo-themed" alt="Vaultwarden" />
+         <div class="spinner-container tw-justify-center">
+           <i
+             class="bwi bwi-spinner bwi-spin bwi-3x tw-text-muted"
+diff --git a/apps/web/src/manifest.json b/apps/web/src/manifest.json
+index 92a1204c60..d9ff4771a3 100644
+--- a/apps/web/src/manifest.json
++++ b/apps/web/src/manifest.json
+@@ -1,5 +1,5 @@
+ {
+-  "name": "Bitwarden Vault",
++  "name": "Vaultwarden Web",
+   "icons": [
+     {
+       "src": "images/icons/android-chrome-192x192.png",
+@@ -12,6 +12,6 @@
+       "type": "image/png"
+     }
+   ],
+-  "theme_color": "#175DDC",
+-  "background_color": "#175DDC"
++  "theme_color": "#FFFFFF",
++  "background_color": "#FFFFFF"
+ }
+diff --git a/apps/web/src/scss/tailwind.css b/apps/web/src/scss/tailwind.css
+index 0ae3c291b5..3a28c7868c 100644
+--- a/apps/web/src/scss/tailwind.css
++++ b/apps/web/src/scss/tailwind.css
+@@ -51,7 +51,7 @@
+   img.new-logo-themed {
+     @apply tw-block;
+ 
+-    width: 128px;
++    width: 175px;
+   }
+   .theme_light img.new-logo-themed {
+     content: url("../images/logo.svg");
+diff --git a/apps/web/tailwind.config.js b/apps/web/tailwind.config.js
+index 4a3f6cfef1..8b1d6081a6 100644
+--- a/apps/web/tailwind.config.js
++++ b/apps/web/tailwind.config.js
+@@ -8,7 +8,6 @@ config.content = [
+   "../../libs/key-management-ui/src/**/*.{html,ts}",
+   "../../libs/vault/src/**/*.{html,ts}",
+   "../../libs/angular/src/**/*.{html,ts}",
+-  "../../bitwarden_license/bit-web/src/**/*.{html,ts}",
+ ];
+ 
+ module.exports = config;
+diff --git a/apps/web/tsconfig.json b/apps/web/tsconfig.json
+index 3d62a30bc0..57f53c0980 100644
+--- a/apps/web/tsconfig.json
++++ b/apps/web/tsconfig.json
+@@ -10,7 +10,6 @@
+       "@bitwarden/auth/angular": ["../../libs/auth/src/angular"],
+       "@bitwarden/auth/common": ["../../libs/auth/src/common"],
+       "@bitwarden/billing": ["../../libs/billing/src"],
+-      "@bitwarden/bit-common/*": ["../../bitwarden_license/bit-common/src/*"],
+       "@bitwarden/common/*": ["../../libs/common/src/*"],
+       "@bitwarden/components": ["../../libs/components/src"],
+       "@bitwarden/generator-components": ["../../libs/tools/generator/components/src"],
+diff --git a/clients.code-workspace b/clients.code-workspace
+index f7d86d2a24..75389727d2 100644
+--- a/clients.code-workspace
++++ b/clients.code-workspace
+@@ -8,18 +8,10 @@
+       "name": "web vault",
+       "path": "apps/web",
+     },
+-    {
+-      "name": "web vault (bit)",
+-      "path": "bitwarden_license/bit-web",
+-    },
+     {
+       "name": "cli",
+       "path": "apps/cli",
+     },
+-    {
+-      "name": "cli (bit)",
+-      "path": "bitwarden_license/bit-cli",
+-    },
+     {
+       "name": "desktop",
+       "path": "apps/desktop",
+@@ -32,10 +24,6 @@
+       "name": "libs",
+       "path": "libs",
+     },
+-    {
+-      "name": "common (bit)",
+-      "path": "bitwarden_license/bit-common",
+-    },
+   ],
+   "settings": {
+     "eslint.options": {
+diff --git a/jest.config.js b/jest.config.js
+index e8815f92ff..c635c2fc45 100644
+--- a/jest.config.js
++++ b/jest.config.js
+@@ -20,9 +20,6 @@ module.exports = {
+     "<rootDir>/apps/cli/jest.config.js",
+     "<rootDir>/apps/desktop/jest.config.js",
+     "<rootDir>/apps/web/jest.config.js",
+-    "<rootDir>/bitwarden_license/bit-web/jest.config.js",
+-    "<rootDir>/bitwarden_license/bit-cli/jest.config.js",
+-    "<rootDir>/bitwarden_license/bit-common/jest.config.js",
+ 
+     "<rootDir>/libs/admin-console/jest.config.js",
+     "<rootDir>/libs/angular/jest.config.js",
+diff --git a/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts b/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
+index 04dc3b6dfd..2791b0bc17 100644
+--- a/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
++++ b/libs/auth/src/angular/anon-layout/anon-layout-wrapper.component.ts
+@@ -8,6 +8,8 @@ import { AnonLayoutComponent } from "@bitwarden/auth/angular";
+ import { I18nService } from "@bitwarden/common/platform/abstractions/i18n.service";
+ import { Icon, Translation } from "@bitwarden/components";
+ 
++import { BitwardenShield } from "../icons";
++
+ import { AnonLayoutWrapperDataService } from "./anon-layout-wrapper-data.service";
+ 
+ export interface AnonLayoutWrapperData {
+@@ -160,7 +162,7 @@ export class AnonLayoutWrapperComponent implements OnInit, OnDestroy {
+   private resetPageData() {
+     this.pageTitle = null;
+     this.pageSubtitle = null;
+-    this.pageIcon = null;
++    this.pageIcon = BitwardenShield;
+     this.showReadonlyHostname = null;
+     this.maxWidth = null;
+     this.titleAreaMaxWidth = null;
+diff --git a/libs/auth/src/angular/anon-layout/anon-layout.component.html b/libs/auth/src/angular/anon-layout/anon-layout.component.html
+index 4120ea5900..1adea588fd 100644
+--- a/libs/auth/src/angular/anon-layout/anon-layout.component.html
++++ b/libs/auth/src/angular/anon-layout/anon-layout.component.html
+@@ -8,7 +8,7 @@
+   <a
+     *ngIf="!hideLogo"
+     [routerLink]="['/']"
+-    class="tw-w-[128px] tw-block tw-mb-12 [&>*]:tw-align-top"
++    class="tw-w-[175px] tw-block tw-mb-12 [&>*]:tw-align-top"
+   >
+     <bit-icon [icon]="logo"></bit-icon>
+   </a>
+@@ -55,8 +55,14 @@
+       <ng-content select="[slot=environment-selector]"></ng-content>
+     </ng-container>
+     <ng-container *ngIf="!hideYearAndVersion">
+-      <div bitTypography="body2">&copy; {{ year }} Bitwarden Inc.</div>
++      <div bitTypography="body2">Vaultwarden Web</div>
+       <div bitTypography="body2">{{ version }}</div>
++      <br />
++      <div bitTypography="helper" id="vw-disclaimer">
++        A modified version of the Bitwarden&reg; Web Vault for Vaultwarden (an unofficial rewrite of
++        the Bitwarden&reg; server).<br />
++        Vaultwarden is not associated with the Bitwarden&reg; project nor Bitwarden Inc.
++      </div>
+     </ng-container>
+   </footer>
+ </main>
+diff --git a/libs/auth/src/angular/login/login-secondary-content.component.ts b/libs/auth/src/angular/login/login-secondary-content.component.ts
+index b608542b37..4f0b86baa7 100644
+--- a/libs/auth/src/angular/login/login-secondary-content.component.ts
++++ b/libs/auth/src/angular/login/login-secondary-content.component.ts
+@@ -11,7 +11,6 @@ import { LinkModule } from "@bitwarden/components";
+   imports: [CommonModule, JslibModule, LinkModule, RouterModule],
+   template: `
+     <div class="tw-text-center" *ngIf="!(isUserRegistrationDisabled$ | async)">
+-      {{ "newToBitwarden" | i18n }}
+       <a bitLink routerLink="/signup">{{ "createAccount" | i18n }}</a>
+     </div>
+   `,
+diff --git a/libs/auth/src/angular/registration/registration-start/registration-start.component.html b/libs/auth/src/angular/registration/registration-start/registration-start.component.html
+index de3611a597..23a7324566 100644
+--- a/libs/auth/src/angular/registration/registration-start/registration-start.component.html
++++ b/libs/auth/src/angular/registration/registration-start/registration-start.component.html
+@@ -53,7 +53,7 @@
+       {{ "continue" | i18n }}
+     </button>
+ 
+-    <p bitTypography="helper" class="tw-text-main tw-text-xs tw-mb-0">
++    <p bitTypography="helper" class="tw-text-main tw-text-xs tw-mb-0" *ngIf="!isSelfHost">
+       {{ "byContinuingYouAgreeToThe" | i18n }}
+       <a
+         bitLink
+diff --git a/libs/common/src/admin-console/models/domain/organization.ts b/libs/common/src/admin-console/models/domain/organization.ts
+index 6f7ff561f0..8e5da8470a 100644
+--- a/libs/common/src/admin-console/models/domain/organization.ts
++++ b/libs/common/src/admin-console/models/domain/organization.ts
+@@ -365,6 +365,7 @@ export class Organization {
+   }
+ 
+   get canAccessIntegrations() {
++    return false; // disable integrations for Vaultwarden
+     return (
+       (this.productTierType === ProductTierType.Teams ||
+         this.productTierType === ProductTierType.Enterprise) &&
+diff --git a/libs/components/src/tw-theme.css b/libs/components/src/tw-theme.css
+index 3bc7cd3d81..27e09b876e 100644
+--- a/libs/components/src/tw-theme.css
++++ b/libs/components/src/tw-theme.css
+@@ -12,13 +12,13 @@
+   --color-background: 255 255 255;
+   --color-background-alt: 243 246 249;
+   --color-background-alt2: 23 92 219;
+-  --color-background-alt3: 26 65 172;
+-  --color-background-alt4: 2 15 102;
++  --color-background-alt3: 33 37 41; /* bg of menu panel */
++  --color-background-alt4: 16 18 21; /* bg of active menu item */
+ 
+   --color-primary-100: 219 229 246;
+-  --color-primary-300: 121 161 233;
+-  --color-primary-600: 23 93 220;
+-  --color-primary-700: 26 65 172;
++  --color-primary-300: 108 117 125; /* hover of menu items */
++  --color-primary-600: 18 82 163; /* color of links and buttons */
++  --color-primary-700: 13 60 119; /* hover of links and buttons */
+ 
+   --color-secondary-100: 230 233 239;
+   --color-secondary-300: 168 179 200;
+@@ -54,7 +54,7 @@
+   --color-text-alt2: 255 255 255;
+   --color-text-code: 192 17 118;
+ 
+-  --color-marketing-logo: 23 93 220;
++  --color-marketing-logo: 15 15 15; /* The Vaultwarden Logo */
+ 
+   --tw-ring-offset-color: #ffffff;
+ }
+diff --git a/libs/components/tailwind.config.js b/libs/components/tailwind.config.js
+index 2df648723f..be4e907625 100644
+--- a/libs/components/tailwind.config.js
++++ b/libs/components/tailwind.config.js
+@@ -7,7 +7,6 @@ config.content = [
+   "libs/vault/src/**/*.{html,ts,mdx}",
+   "apps/web/src/**/*.{html,ts,mdx}",
+   "apps/browser/src/**/*.{html,ts,mdx}",
+-  "bitwarden_license/bit-web/src/**/*.{html,ts,mdx}",
+   ".storybook/preview.tsx",
+ ];
+ config.safelist = [
+diff --git a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
+index 322fea94e3..84ce3785de 100644
+--- a/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
++++ b/libs/tools/send/send-ui/src/send-form/components/options/send-options.component.html
+@@ -13,7 +13,7 @@
+     </bit-form-field>
+     <bit-form-field>
+       <bit-label>{{ (passwordRemoved ? "newPassword" : "password") | i18n }}</bit-label>
+-      <input bitInput type="password" formControlName="password" />
++      <input bitInput type="password" formControlName="password" autocomplete="new-password" />
+       <button
+         data-testid="toggle-visibility-for-password"
+         type="button"
+diff --git a/tailwind.config.js b/tailwind.config.js
+index 637c28a54e..7afcea4e65 100644
+--- a/tailwind.config.js
++++ b/tailwind.config.js
+@@ -10,7 +10,6 @@ config.content = [
+   "./libs/tools/send/send-ui/src/*.{html,ts,mdx}",
+   "./libs/vault/src/**/*.{html,ts,mdx}",
+   "./apps/web/src/**/*.{html,ts,mdx}",
+-  "./bitwarden_license/bit-web/src/**/*.{html,ts,mdx}",
+   "./.storybook/preview.js",
+ ];
+ config.safelist = [
+diff --git a/tsconfig.json b/tsconfig.json
+index fb50f1e703..4f5f81279c 100644
+--- a/tsconfig.json
++++ b/tsconfig.json
+@@ -56,9 +56,7 @@
+     "apps/browser/src/**/*",
+     "libs/*/src/**/*",
+     "libs/tools/send/**/src/**/*",
+-    "libs/tools/card/src/**/*",
+-    "bitwarden_license/bit-web/src/**/*",
+-    "bitwarden_license/bit-common/src/**/*"
++    "libs/tools/card/src/**/*"
+   ],
+   "exclude": [
+     "apps/web/src/**/*.spec.ts",


### PR DESCRIPTION
New web-vault release: [web-v2025.1.2](https://github.com/bitwarden/clients/releases/tag/web-v2025.1.2)

I've re-enabled the calling of the collection-managment endpoint (and also the environment-selector is not patched out anymore).

There's a new endpoint needed for email verification on signup: `/identity/accounts/register/send-verification-email`
```json
{"email":"test@example.com","name":"test","receiveMarketingEmails":false}
```

I have not looked much into it so I'm not sure if we can implement this in a way so that Vaultwarden will be usable without enabling mails. Does a self-hosted Bitwarden server require that?