### PR TITLE
fix local build version

### DIFF
--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -55,5 +55,5 @@ pushd "${VAULT_FOLDER}"
     # Update branch and tag metadata
     git fetch --depth 1 ${CHECKOUT_ARGS:-} vaultwarden "${VAULT_VERSION}"
     # Checkout the branch we want
-    git -c advice.detachedHead=false checkout FETCH_HEAD
+    git -c advice.detachedHead=false checkout "${VAULT_VERSION}"
 popd


### PR DESCRIPTION
Since we have switched to using our own repository I think it should be fine to revert the checkout to the requested branch, tag or git hash instead, so the `tag` and `branch` info could be used for local building if requested explicitly. (However, I am not sure why we switched to `FETCH_HEAD` in the first place.)

Thanks to @kpfleming for pointing this out.