### PR TITLE
use v2025.5.1 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.5.0
-ARG VAULT_VERSION=93c4d42c84c50998663900a446e027319d8ef74e
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.5.1
+ARG VAULT_VERSION=ef718f0da441fe2a7d51ae4931efff0e3d0ecf13
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false


### PR DESCRIPTION
Update to use new web-vault. Also added new css classes for the or text and login with passkey button and sso login button on the login page, cf. https://github.com/vaultwarden/vw_web_builds/commit/045b0cf85c429d76de424652376eacb3a564721f
So we can hide those elements explicitly and more reliably as suggested in https://github.com/dani-garcia/vaultwarden/pull/5890. (Once we update the web-vault to `v2025.5.1` we can change the selectors to `.vw-sso-login`, `.vw-passkey-login` and `.vw-or-text` respectively.)