### PR TITLE
update web-vault to v2025.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.5.1
-ARG VAULT_VERSION=c51d0e09303a86aeda91d9877df4b025edb9a060
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.6.0
+ARG VAULT_VERSION=2aac8b6c6fdb62fb273076e629f7e0837ee29e91
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false


### PR DESCRIPTION
I've updated the `package-lock.json` https://github.com/bitwarden/clients/commit/2aac8b6c6fdb62fb273076e629f7e0837ee29e91 because [`web-v2025.6.0`](https://github.com/bitwarden/clients/releases/tag/web-v2025.6.0) could not be built with `npm ci` otherwise:
```
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm error
npm error Missing: fast-glob@3.3.3 from lock file
npm error Missing: glob-parent@5.1.2 from lock file
```

The seat limit check has been commented out https://github.com/bitwarden/clients/commit/1c7e78e59e5a6d64fde3f47862ebfe54b1018939

Also I've undone the removal of `<app-webauthn-login-settings>` (https://github.com/vaultwarden/vw_web_builds/commit/08498dd2059d10f1eed7dd6082619686f4118bd7)