### PR TITLE
update web-vault to v2025.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.6.1
-ARG VAULT_VERSION=1b257e0cc69f766c2eec83d45e8be2274643ae98
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.6.2
+ARG VAULT_VERSION=483603bec7ce34ecea3cdf30d1b1757e2708d80c
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2025.6.1
+FALLBACK_WEBVAULT_VERSION=v2025.6.2
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
The new web-vault `web-v2025.6.1` has done away with a feature flag that requires some changes in the Vaultwarden backend that we have not implemented yet. I.e. deleting entries would not be possible with newer clients ( https://github.com/dani-garcia/vaultwarden/discussions/5996). So I would wait for a new Vaultwarden release before updating to the newest web-vault.