### PR TITLE
update to v2025.7.0 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,14 @@
 #    Note: you can use --build-arg to specify the version to build:
 #    docker build -t web_vault_build --build-arg VAULT_VERSION=main .
 
-FROM node:20-bookworm AS build
+FROM node:22-bookworm AS build
 RUN node --version && npm --version
 
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.6.2
-ARG VAULT_VERSION=483603bec7ce34ecea3cdf30d1b1757e2708d80c
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.7.0
+ARG VAULT_VERSION=20e3be7a2e0d487cad29a10dbf8afca6a255cde4
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2025.6.2
+FALLBACK_WEBVAULT_VERSION=v2025.7.0
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
Update to the newest web-vault. I've also removed the `sendAccessTaglineProductDesc` as discussed in https://github.com/dani-garcia/vaultwarden/discussions/6029 and the node version is updated to 22 in the Dockerfile since upstream has updated it (cf. https://github.com/bitwarden/clients/commit/4c2475a515681e8b1a66c509bbc890de8af23736)