### PR TITLE
update to v2025.7.1 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.7.0
-ARG VAULT_VERSION=20e3be7a2e0d487cad29a10dbf8afca6a255cde4
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.7.1
+ARG VAULT_VERSION=6f7883175deae147acdd28bc63f66cc4eac5f8d2
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2025.7.0
+FALLBACK_WEBVAULT_VERSION=v2025.7.1
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
update to newest web-vault which includes the new error message if subtle crypto api is not available (cf. https://github.com/vaultwarden/vw_web_builds/pull/19). I've also removed the old error message (https://github.com/vaultwarden/vw_web_builds/commit/1fec36c1d3bad9409b88357cf79cdf66c2efb885) and added a custom css class `vw-signup-link` (https://github.com/vaultwarden/vw_web_builds/commit/49bd697de59af5c647eafe410dd5c275393bdc5f) for making hiding the signup link via custom css easier (because of https://github.com/dani-garcia/vaultwarden/pull/6113).