### PR TITLE
update to v2025.8.0 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.7.2
-ARG VAULT_VERSION=73d202d8294ceb0e4ea86d9bcb1d89fdfec17cb2
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.8.0
+ARG VAULT_VERSION=22f48fd3a062d6cda4f0a468055b738e857620f7
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2025.7.2
+FALLBACK_WEBVAULT_VERSION=v2025.8.0
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
Update to newest [`web-v2025.8.0`](https://github.com/bitwarden/clients/releases/tag/web-v2025.8.0) release.

Our [patch set](https://github.com/bitwarden/clients/compare/web-v2025.8.0...vaultwarden:vw_web_builds:v2025.8.0) (temporarily) removes the integrations tab completely from the code (https://github.com/vaultwarden/vw_web_builds/commit/22f48fd3a062d6cda4f0a468055b738e857620f7) because it's dependent on proprietary code and would not compile otherwise and removing the offending code is easier to maintain than reverting the change and trying to keep our fork up to date with newer changes. (The dependency was most likely introduced in https://github.com/bitwarden/clients/pull/15757)