### PR TITLE
Fix duo redirect logo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN node --version && npm --version
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
 # Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.9.1
-ARG VAULT_VERSION=16f938d544c0777f47b2595985986287149341be
+ARG VAULT_VERSION=19dcdf9ba962ea93ada7d69c8a9cd1c0b4c519fa
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false


### PR DESCRIPTION
This updates the branch to include https://github.com/vaultwarden/vw_web_builds/commit/19dcdf9ba962ea93ada7d69c8a9cd1c0b4c519fa  because I missed that upstream changed the logo on the duo_redirect.html page. I've reverted that change but I'm not sure if this has an effect on dark mode or if that page is only available in light mode. If so we probably need to decide on a color that works on both dark and light mode to have a visible logo on both...