### PR TITLE
update to v2025.12.0 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.10.1
-ARG VAULT_VERSION=f2fac1392de3736e329e57784a09823688e2281d
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.12.0
+ARG VAULT_VERSION=cc8cb941058fea67e525e6075ff13fc1f4aa924e
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2025.10.1
+FALLBACK_WEBVAULT_VERSION=v2025.12.0
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
update to new web-vault release: [web-v2025.12.0](https://github.com/bitwarden/clients/releases/tag/web-v2025.12.0)

as far as I've looked into it upstream added [a few new policies](https://github.com/bitwarden/clients/blob/web-v2025.12.0/libs/common/src/admin-console/enums/policy-type.enum.ts) which we don't support yet (at least the UriMatchDefaults one seems to be available in the open source build).
<img width="665" height="86" alt="image" src="https://github.com/user-attachments/assets/2342792f-3a4d-4ac0-acd1-d0d39ce71e67" />
(so this does not work yet)

and the access intelligence has been disabled since we don't support that.