### PR TITLE
ci: fix push trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ permissions: {}
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?'
 
 jobs:
   docker-build:


### PR DESCRIPTION
the current trigger no longer applies.

I've updated it accordingly. I also escaped the `.`, otherwise any character is valid.

e.g. `v1234h12l45` currently also triggers the workflow.

/ref https://github.com/dani-garcia/bw_web_builds/pull/224#issuecomment-3702994164