### PR TITLE
update to v2026.1.0 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2025.12.2
-ARG VAULT_VERSION=94a4707f0e24689d924bc945eaf157c81b50ebf4
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.1.0
+ARG VAULT_VERSION=d00cab70b73d49621f9623bc9f5665e9ddc59629
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2025.12.2
+FALLBACK_WEBVAULT_VERSION=v2026.1.0
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
update to new web-vault release: [web-v2026.1.0](https://github.com/bitwarden/clients/releases/tag/web-v2026.1.0)