### PR TITLE
update to v2026.2.0 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.1.1
-ARG VAULT_VERSION=ead49a08325ba8e835821d3f78f7b77df3020e63
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.2.0
+ARG VAULT_VERSION=3986035910f6ad172c8ceabcd378e2ca0d25349c
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2026.1.1
+FALLBACK_WEBVAULT_VERSION=v2026.2.0
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
update to new web-vault release: [web-v2026.2.0](https://github.com/bitwarden/clients/releases/tag/web-v2026.2.0)

this now includes the css change directly so #234 can be closed if we don't want to make a hotfix release.