### PR TITLE
update to v2026.3.1 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.2.1
-ARG VAULT_VERSION=280c5d4285faee673c4ff044ad35110c7e3cde05
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.3.1
+ARG VAULT_VERSION=cd1eb788b667bdf31aee2d8b32aae7718c59097e
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.2.0
-ARG VAULT_VERSION=3986035910f6ad172c8ceabcd378e2ca0d25349c
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.2.1
+ARG VAULT_VERSION=280c5d4285faee673c4ff044ad35110c7e3cde05
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2026.2.0
+FALLBACK_WEBVAULT_VERSION=v2026.2.1
 
 # Error handling
 handle_error() {

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2026.2.1
+FALLBACK_WEBVAULT_VERSION=v2026.3.1
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
update to new web-vault release: [web-v2026.2.1](https://github.com/bitwarden/clients/releases/tag/web-v2026.2.1)

I think some server side changes are probably necessary for email protected Sends to work but I have not really looked into it.

I've also added the css class `vw-remember` https://github.com/vaultwarden/vw_web_builds/commit/84903f6dc0fe59fb873170381f7949e6ffd010e8 so we can hide the checkbox position independently, cf. https://github.com/dani-garcia/vaultwarden/pull/6852 