### PR TITLE
update to v2026.4.1 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.3.1
-ARG VAULT_VERSION=cd1eb788b667bdf31aee2d8b32aae7718c59097e
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.4.1
+ARG VAULT_VERSION=e564bf7c687fb12a88dd8b53beff726eb23ea932
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN node --version && npm --version
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
 # Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.4.1
-ARG VAULT_VERSION=e564bf7c687fb12a88dd8b53beff726eb23ea932
+ARG VAULT_VERSION=876c4dbd526add221223d4869d75eb61efe57e37
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2026.3.1
+FALLBACK_WEBVAULT_VERSION=v2026.4.1
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
update to new web-vault release: [`web-v2026.4.1`](https://github.com/bitwarden/clients/releases/tag/web-v2026.4.1)

as said in #238 the `/identity/accounts/prelogin` has been changed to `/identity/accounts/prelogin/password` and also some feature flags have been removed already in [`web-v2026.4.0` ](https://github.com/bitwarden/clients/releases/tag/web-v2026.4.0)