### PR TITLE
update to v2026.6.2 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.6.0
-ARG VAULT_VERSION=13f9a3ae689f422b9c5ef3bb63c7c8ddb5035f45
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.6.2
+ARG VAULT_VERSION=5756400aa48cc39a73984461f8d7c0ddf6feaa28
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.4.1
-ARG VAULT_VERSION=876c4dbd526add221223d4869d75eb61efe57e37
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.5.0
+ARG VAULT_VERSION=fa4722a72b5ef8a113e1f398d2306aa56e31280d
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.5.0
-ARG VAULT_VERSION=fa4722a72b5ef8a113e1f398d2306aa56e31280d
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.6.0
+ARG VAULT_VERSION=13f9a3ae689f422b9c5ef3bb63c7c8ddb5035f45
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2026.5.0
+FALLBACK_WEBVAULT_VERSION=v2026.6.0
 
 # Error handling
 handle_error() {

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2026.6.0
+FALLBACK_WEBVAULT_VERSION=v2026.6.2
 
 # Error handling
 handle_error() {

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2026.4.1
+FALLBACK_WEBVAULT_VERSION=v2026.5.0
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
update to new web-vault: [`web-v2026.5.0`](https://github.com/bitwarden/clients/releases/tag/web-v2026.5.0)

I've not really looked very deeply into the list of changes but it seems like they removed at least the feature flag `pm-27086-update-authentication-apis-for-input-password`  https://github.com/bitwarden/clients/pull/20306 that requires us to change a few things.