### PR TITLE
update to v2026.6.4 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.6.2
-ARG VAULT_VERSION=5756400aa48cc39a73984461f8d7c0ddf6feaa28
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.6.4
+ARG VAULT_VERSION=ad8147249289918a9d77492596e088b75f1ff3fb
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2026.6.2
+FALLBACK_WEBVAULT_VERSION=v2026.6.4
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
update to new web-vault: [web-v2026.6.4](https://github.com/bitwarden/clients/releases/tag/web-v2026.6.4)

this depends on https://github.com/dani-garcia/vaultwarden/pull/7434 