### PR TITLE
update to v2026.7.1 branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN node --version && npm --version
 # Can be a tag, release, but prefer a commit hash because it's not changeable
 # https://github.com/bitwarden/clients/commit/${VAULT_VERSION}
 #
-# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.7.0
-ARG VAULT_VERSION=d2a095eb800fe80a9bc524579b974796eae51994
+# Using https://github.com/vaultwarden/vw_web_builds/tree/v2026.7.1
+ARG VAULT_VERSION=5cdff3717fa3c8d7be40f26b6e073df150784095
 ENV VAULT_VERSION=$VAULT_VERSION
 ENV VAULT_FOLDER=bw_clients
 ENV CHECKOUT_TAGS=false

--- a/scripts/checkout_web_vault.sh
+++ b/scripts/checkout_web_vault.sh
@@ -2,7 +2,7 @@
 set -o pipefail -o errexit
 BASEDIR=$(RL=$(readlink -n "$0"); SP="${RL:-$0}"; dirname "$(cd "$(dirname "${SP}")"; pwd)/$(basename "${SP}")")
 
-FALLBACK_WEBVAULT_VERSION=v2026.7.0
+FALLBACK_WEBVAULT_VERSION=v2026.7.1
 
 # Error handling
 handle_error() {


### PR DESCRIPTION
update to new web-vault: [web-v2026.7.1](https://github.com/bitwarden/clients/releases/tag/web-v2026.7.1)

The feature flag `pm-34145-policies-in-accepted-state` has been removed (https://github.com/bitwarden/clients/pull/21761) so it requires the policies to have a revision date as well. Otherwise if you are member of an organization with a policies [this call will fail](https://github.com/bitwarden/clients/blob/7b73ec614dfcfb192e5552cdf0fb5380d784746d/libs/common/src/admin-console/models/domain/policy.ts#L67) and this exception will make the web-vault completely inaccessible.
<img width="1521" height="766" alt="image" src="https://github.com/user-attachments/assets/7858f98e-bb14-4ec6-97ea-27ec2a0a329e" />

So this should be addressed first in the Vaultwarden backend. (I can do a PR for returning an empty revision date to make it compatible (i.e. add `"revisionDate": null,`) but I currently don't have the time to look properly into this.)